### PR TITLE
Added functionality for forwarding and replying a mail containing HTML content. Also, HTML content was made to be in editable format for implementing this functionality.

### DIFF
--- a/Source/CTCoreMessage.h
+++ b/Source/CTCoreMessage.h
@@ -102,6 +102,11 @@
  */
 - (NSString *)htmlBody;
 
+/*!
+ @abstract	This method returns the editable html body as an NSString.
+ */
+- (NSString *)editableHtmlBody;
+
 /*!  @abstract Returns a message body as an NSString. First attempts
                to retrieve a plain text body, if that fails then
                tries for an HTML body.
@@ -112,6 +117,8 @@
 	@abstract	This method sets the message body. Plaintext only please!
 */
 - (void)setBody:(NSString *)body;
+
+- (void) setHTMLBody:(NSString *)body
 
 - (NSArray *)attachments;
 - (void)addAttachment:(CTCoreAttachment *)attachment;

--- a/Source/CTCoreMessage.h
+++ b/Source/CTCoreMessage.h
@@ -118,7 +118,7 @@
 */
 - (void)setBody:(NSString *)body;
 
-- (void) setHTMLBody:(NSString *)body
+- (void)setHTMLBody:(NSString *)body;
 
 - (NSArray *)attachments;
 - (void)addAttachment:(CTCoreAttachment *)attachment;

--- a/Source/CTCoreMessage.m
+++ b/Source/CTCoreMessage.m
@@ -39,6 +39,7 @@
 #import "CTMIME_MultiPart.h"
 #import "CTMIME_SinglePart.h"
 #import "CTBareAttachment.h"
+#import "CTMIME_HtmlPart.h"
 
 @interface CTCoreMessage (Private)
 - (CTCoreAddress *)_addressFromMailbox:(struct mailimf_mailbox *)mailbox;
@@ -144,6 +145,18 @@ char * etpan_encode_mime_header(char * phrase)
 	return result;
 }
 
+- (NSString *)editableHtmlBody{
+    //added by KK
+    NSMutableString *result = [NSMutableString string];
+	[self _buildUpHtmlBodyText:myParsedMIME result:result];
+    NSString *str = [NSString stringWithFormat:@"<div id = 'myDiv' contentEditable>"];
+    str = [str stringByAppendingFormat:@"%@",[NSString stringWithString:result]];
+    str = [str stringByAppendingString:@"</div>"];
+    //Used For Getting changed content
+    str = [str stringByAppendingString:@"<script type = 'text/javascript'> function getHtmlContent() { return document.getElementById('myDiv').innerHTML;}</script>"];
+	return str;
+}
+
 - (NSString *)bodyPreferringPlainText {
     NSString *body = [self body];
     if ([body length] == 0) {
@@ -220,6 +233,14 @@ char * etpan_encode_mime_header(char * phrase)
 		myParsedMIME = [messagePart retain];
 		[oldMIME release];		
 	}
+}
+
+- (void) setHTMLBody:(NSString *)body{
+    CTMIME *oldMIME = myParsedMIME;
+	CTMIME_HtmlPart *text = [CTMIME_HtmlPart mimeTextPartWithString:body];
+    CTMIME_MessagePart *messagePart = [CTMIME_MessagePart mimeMessagePartWithContent:text];
+    myParsedMIME = [messagePart retain];
+    [oldMIME release];	
 }
 
 - (NSArray *)attachments {

--- a/Source/CTMIME_HtmlPart.h
+++ b/Source/CTMIME_HtmlPart.h
@@ -1,0 +1,17 @@
+//
+//  CTMIME_HtmlPart.h
+//  EazyPractice
+//
+//  Created by Kaustubh Kabra on 06/01/12.
+//  Copyright (c) 2012 Xtremum Solutions. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CTMIME_SinglePart.h"
+
+@interface CTMIME_HtmlPart : CTMIME_SinglePart {
+}
++ (id)mimeTextPartWithString:(NSString *)str;
+- (id)initWithString:(NSString *)string;
+- (void)setString:(NSString *)str;
+@end

--- a/Source/CTMIME_HtmlPart.m
+++ b/Source/CTMIME_HtmlPart.m
@@ -1,0 +1,94 @@
+//
+//  CTMIME_HtmlPart.m
+//  EazyPractice
+//
+//  Created by Kaustubh Kabra on 06/01/12.
+//  Copyright (c) 2012 Xtremum Solutions. All rights reserved.
+//
+
+#import "CTMIME_HtmlPart.h"
+
+#import <libetpan/libetpan.h>
+#import "MailCoreTypes.h"
+
+@implementation CTMIME_HtmlPart
+
++ (id)mimeTextPartWithString:(NSString *)str {
+	return [[[CTMIME_HtmlPart alloc] initWithString:str] autorelease];
+}
+
+- (id)initWithString:(NSString *)string {
+	self = [super init];
+	if (self) {
+		[self setString:string];
+	}
+	return self;
+}
+
+- (id)content {
+	if (mMimeFields != NULL) {
+		// We are decoding from an existing msg so read
+		// the charset and convert from that to UTF-8
+		char *converted;
+		size_t converted_len;
+		
+		char *source_charset = mMimeFields->fld_content_charset;
+		if (source_charset == NULL) {
+			source_charset = DEST_CHARSET;
+		}
+		
+		int r = charconv_buffer(DEST_CHARSET, source_charset,
+								self.data.bytes, self.data.length,
+								&converted, &converted_len);
+		NSString *str = @"";
+		if (r == MAIL_CHARCONV_NO_ERROR) {
+			NSData *newData = [NSData dataWithBytes:converted length:converted_len];
+			str = [[[NSString alloc] initWithData:newData encoding:NSUTF8StringEncoding] autorelease];
+		}
+		charconv_buffer_free(converted);
+		return str;
+	} else {
+		// Don't have a charset available so treat data as UTF-8
+		// This will happen when we are creating a msg and not decoding
+		// an existing one
+		return [[[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding] autorelease];
+	}
+}
+
+- (void)setString:(NSString *)str {
+	self.data = [str dataUsingEncoding:NSUTF8StringEncoding];
+	// The data is all local, so we don't want it to do any fetching
+	self.fetched = YES;
+}
+
+- (struct mailmime *)buildMIMEStruct {
+	struct mailmime_fields *mime_fields;
+	struct mailmime *mime_sub;
+	struct mailmime_content *content;
+	struct mailmime_parameter *param;
+	int r;
+    
+	/* text/plain part */
+	//TODO this needs to be changed, something other than 8BIT should be used
+	mime_fields = mailmime_fields_new_encoding(MAILMIME_MECHANISM_8BIT);
+	assert(mime_fields != NULL);
+    
+	content = mailmime_content_new_with_str("text/html");
+	assert(content != NULL);
+    
+	param = mailmime_parameter_new(strdup("charset"), strdup(DEST_CHARSET));
+	assert(param != NULL);
+	
+	r = clist_append(content->ct_parameters, param);
+	assert(r >= 0);
+    
+	mime_sub = mailmime_new_empty(content, mime_fields);
+	assert(mime_sub != NULL);
+	NSString *str = [self content];
+	//TODO is strdup necessary?
+	r = mailmime_set_body_text(mime_sub, strdup([str cStringUsingEncoding:NSUTF8StringEncoding]), [str length]);
+	assert(r == MAILIMF_NO_ERROR);
+	return mime_sub;
+}
+
+@end

--- a/Source/CTMIME_HtmlPart.m
+++ b/Source/CTMIME_HtmlPart.m
@@ -68,7 +68,7 @@
 	struct mailmime_parameter *param;
 	int r;
     
-	/* text/plain part */
+	/* text/html part */
 	//TODO this needs to be changed, something other than 8BIT should be used
 	mime_fields = mailmime_fields_new_encoding(MAILMIME_MECHANISM_8BIT);
 	assert(mime_fields != NULL);


### PR DESCRIPTION
1.Composing editable html mail ->Use function "editableHtmlBody" in CTCoreMessage for loading HTML editable body in a UIWebView , (Edit in web view is supported since iOS 5.0)

2.Getting editable content -> Use function [<UIWebView instance> stringByEvaluatingJavaScriptFromString:@"getHtmlContent()"] to get edited HTML string.

3.Sending edited html mail -> Use function "setHTMLBody" in CTCoreMessage for setting this html body as mail body.

Also, there needs to be a check whether the body is Plaintext or html, and accordingly these or existing operations should be performed.
