### PR TITLE
Fix for crash in async SMTP connection cleanup

### DIFF
--- a/Source/CTSMTPAsyncConnection.m
+++ b/Source/CTSMTPAsyncConnection.m
@@ -246,12 +246,14 @@ smtpProgress( size_t aCurrent, size_t aTotal )
 
     if( mSMTP )
     {
-        mailstream_cancel(mSMTP->stream);
-        mailstream_close(mSMTP->stream);
-        mSMTP->stream = NULL;
+        if( mSMTP->stream )
+        {
+			mailstream_cancel(mSMTP->stream);
+			mailstream_close(mSMTP->stream);
+			mSMTP->stream = NULL;
+		}
         mailsmtp_free(mSMTP);
         mSMTP = NULL;
-
     }
 
     [mServerSettings release];

--- a/Source/CTSMTPAsyncConnection.m
+++ b/Source/CTSMTPAsyncConnection.m
@@ -248,10 +248,10 @@ smtpProgress( size_t aCurrent, size_t aTotal )
     {
         if( mSMTP->stream )
         {
-			mailstream_cancel(mSMTP->stream);
-			mailstream_close(mSMTP->stream);
-			mSMTP->stream = NULL;
-		}
+            mailstream_cancel(mSMTP->stream);
+            mailstream_close(mSMTP->stream);
+            mSMTP->stream = NULL;
+        }
         mailsmtp_free(mSMTP);
         mSMTP = NULL;
     }


### PR DESCRIPTION
This was reported by a user behind a corporate firewall. I was able to reproduce the stack by blocking the designated outgoing SMTP port on my local machine.
