### PR TITLE
added an inReplyTo method to CTCoreMessage

### DIFF
--- a/Source/CTCoreMessage.h
+++ b/Source/CTCoreMessage.h
@@ -263,6 +263,11 @@ The local timezone is the one set in the device running this code
 - (void)setTo:(NSSet *)addresses;
 
 /**
+Return the list of messageIds from the in-reply-to field
+ */
+- (NSSet *)inReplyTo;
+
+/**
  Returns the list of people the message was cced to, returns an NSSet containing CTAddress's.
 */
 - (NSSet *)cc;

--- a/Source/CTCoreMessage.m
+++ b/Source/CTCoreMessage.m
@@ -505,6 +505,12 @@
         myFields->fld_to = mailimf_to_new(imf);
 }
 
+- (NSSet *)inReplyTo {
+    if (myFields->fld_in_reply_to == NULL)
+        return nil;
+    else
+        return [self _stringSetFromClist:myFields->fld_in_reply_to->mid_list];
+}
 
 - (NSSet *)cc {
     if (myFields->fld_cc == NULL)
@@ -751,6 +757,22 @@
         assert(err == 0);
     }
     return imfList;
+}
+
+- (NSSet *)_stringSetFromClist:(clist *)list {
+    clistiter *iter;
+    NSMutableSet *stringSet = [NSMutableSet set];
+	char *string;
+	
+    if(list == NULL)
+        return stringSet;
+	
+    for(iter = clist_begin(list); iter != NULL; iter = clist_next(iter)) {
+        string = clist_content(iter);
+		[stringSet addObject:[[NSString alloc] initWithUTF8String:string]];
+    }
+	
+    return stringSet;
 }
 
 @end


### PR DESCRIPTION
The underlying libetpan data structure had the inReplyTo stored as a linked list of char *s. The RFC though specifies that the in-reply-to field should be string. I wasn't sure which one should be used so I made it return an NSSet of NSStrings. I tested it though 10s of thousands of messages and it never returned more than one result so maybe it should be changed to just return the first entry as an NSString.
