### PR TITLE
Access to unread messages

### DIFF
--- a/Source/CTCoreFolder.h
+++ b/Source/CTCoreFolder.h
@@ -118,6 +118,17 @@
 */
 - (NSArray *)messagesFromUID:(NSUInteger)startUID to:(NSUInteger)endUID withFetchAttributes:(CTFetchAttributes)attrs;
 
+
+/**
+ Returns the list of UIDs of unread messages
+ */
+- (NSSet *)uidsOfUnreadMessages;
+
+
+/* fetches the messages with UIDs in the set
+ */
+-(NSArray *) messageObjectsWithUIDs:(NSSet *) uids withFetchAttributes:(CTFetchAttributes)attrs;
+
 /**
  Pulls the sequence number for the message with the specified uid.
  It does not perform UID validation, and the sequence ID is only

--- a/Source/CTCoreFolder.m
+++ b/Source/CTCoreFolder.m
@@ -517,16 +517,16 @@ int uid_list_to_env_list(clist * fetch_result, struct mailmessage_list ** result
     if (search_key == NULL) {
         return nil;
     }
-
+    
     r = mailimap_uid_search([self imapSession], NULL, search_key, &fetch_result);
-
+    
     mailimap_search_key_free(search_key);
-
+    
     if (r != MAIL_NO_ERROR) {
         self.lastError = MailCoreCreateErrorFromIMAPCode(r);
         return nil;
     }
-
+    
     NSMutableSet *set = [NSMutableSet setWithCapacity:clist_count(fetch_result)];
     clistiter *iter;
     for(iter = clist_begin(fetch_result); iter != NULL; iter = clist_next(iter)) {
@@ -538,12 +538,11 @@ int uid_list_to_env_list(clist * fetch_result, struct mailmessage_list ** result
 
 
 -(NSArray *) messageObjectsWithUIDs:(NSSet *) uids withFetchAttributes:(CTFetchAttributes)attrs {
-    clist *uid_list = clist_new();
+    struct mailimap_set *uid_set = mailimap_set_new_empty();
+    
     for (NSNumber *boxedUid in uids) {
-        NSUInteger uidInteger = [boxedUid unsignedIntegerValue];
-        clist_append(uid_list, &uidInteger);
+        mailimap_set_add_single(uid_set, [boxedUid unsignedIntegerValue]);
     }
-    struct mailimap_set *uid_set = mailimap_set_new(uid_list);
     return [self messagesForSet:uid_set fetchAttributes:attrs uidFetch:YES];
 }
 

--- a/Source/CTCoreFolder.m
+++ b/Source/CTCoreFolder.m
@@ -631,6 +631,11 @@ int uid_list_to_env_list(clist * fetch_result, struct mailmessage_list ** result
         self.lastError = MailCoreCreateErrorFromIMAPCode(err);
         return NO;
     }
+    err = mailfolder_check(myFolder);
+    if (err != MAIL_NO_ERROR) {
+        self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+        return NO;
+    }
     return YES;
 }
 

--- a/Source/CTMIME_HtmlPart.m
+++ b/Source/CTMIME_HtmlPart.m
@@ -89,11 +89,17 @@
     struct mailmime *mime_sub;
     struct mailmime_content *content;
     struct mailmime_parameter *param;
+    struct mailmime_disposition *disposition;
+    struct mailmime_mechanism *encoding;
+    
     int r;
 
     /* text/html part */
-    //TODO this needs to be changed, something other than 8BIT should be used
-    mime_fields = mailmime_fields_new_encoding(MAILMIME_MECHANISM_8BIT);
+    encoding = mailmime_mechanism_new(MAILMIME_MECHANISM_QUOTED_PRINTABLE, NULL);
+    disposition = mailmime_disposition_new_with_data(MAILMIME_DISPOSITION_TYPE_INLINE, NULL, NULL, NULL, NULL, -1);
+    mime_fields = mailmime_fields_new_with_data(encoding, NULL, NULL, disposition, NULL);
+    
+    
     content = mailmime_content_new_with_str("text/html");
     param = mailmime_parameter_new(strdup("charset"), strdup(DEST_CHARSET));
     r = clist_append(content->ct_parameters, param);


### PR DESCRIPTION
I'm submitting this more as an request for comment than as something I actually want to see included in its current state.

We need to quickly retrieve all the unread messages for a folder and the existing methods didn't really make that possible (unless I've missed something).  If there's another way of doing this, let me know, otherwise what we wanted was:

```
>>>>>>> send >>>>>>
4 UID SEARCH UNSEEN
>>>>>>> end send >>>>>>
<<<<<<< read <<<<<<
* SEARCH 43 44 46 47 301 545 546 548 549 550 551 552 553 554 606
4 OK Search completed (0.000 secs).
<<<<<<< end read <<<<<<
```

After that we fetch the size, and envelope:

```
5 UID FETCH 43,552,551,550,546,47,46,545,554,553,549,606,301,44 (UID FLAGS RFC822.SIZE ENVELOPE BODY.PEEK[HEADER.FIELDS (References)])
```

This is a rather clumsy implementation of the MailCore changes required to implement this functionality, if you could give me some feedback on the implementation strategy and coding style I'll happily update it for inclusion. 
