### PR TITLE
Ensure flag changes are persisted to imap after setFlags:forMesssage: is called

### DIFF
--- a/Source/CTCoreFolder.m
+++ b/Source/CTCoreFolder.m
@@ -587,6 +587,11 @@ int uid_list_to_env_list(clist * fetch_result, struct mailmessage_list ** result
         self.lastError = MailCoreCreateErrorFromIMAPCode(err);
         return NO;
     }
+    err = mailfolder_check(myFolder);
+    if (err != MAIL_NO_ERROR) {
+        self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+        return NO;
+    }
     return YES;
 }
 


### PR DESCRIPTION
With libetpan `mailmessage_check` only updates the in memory store of the flags for a given message, it doesn't make any changes over the wire.  You must ensure that `imap_flags_store_process` is called otherwise the data is lost.

There are a few options for ensuring this is called:
- `imapdriver_uninitialize`
- `imapdriver_logout`
- `imapdriver_check_folder`
- `imapdriver_select_folder`
- `imapdriver_expunge_folder`
- `imapdriver_get_envelopes_list`

Calling `CHECK` seemed the lowest cost alternative out there.

The current implementation of `setFlags:forMessage` only works if you either explicitly log out, expunge or select another folder, my particular application doesn't usually do any of those things as it only handles a single mailbox and is more likely to get suspended by a user than explicitly log out / dealloc the CTCoreFolder
