### PR TITLE
Fixes to MailCore tests; no hard-coding of mail account data, proper test data file access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ xcuserdata
 .DS_Store
 include/
 .idea
+TestData/account.plist

--- a/MailCore.xcodeproj/project.pbxproj
+++ b/MailCore.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		F8EC5B0514C37F60006AF4D3 /* CTMIME_HtmlPart.m in Sources */ = {isa = PBXBuildFile; fileRef = F8EC5B0214C37F60006AF4D3 /* CTMIME_HtmlPart.m */; };
 		F8EC5B0514C37F60006AF4D5 /* CTConnectedTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F8EC5B0514C37F60006AF4D4 /* CTConnectedTest.m */; };
 		F8EC5B0514C37F60006AF4D8 /* CTCoreFolderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F8EC5B0514C37F60006AF4D7 /* CTCoreFolderTests.m */; };
+		F9FC3A731683FC07004B2D1E /* TestData in Resources */ = {isa = PBXBuildFile; fileRef = F9FC3A721683FC07004B2D1E /* TestData */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -298,6 +299,7 @@
 		F8EC5B0514C37F60006AF4D6 /* CTConnectedTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CTConnectedTest.h; path = Tests/CTConnectedTest.h; sourceTree = "<group>"; };
 		F8EC5B0514C37F60006AF4D7 /* CTCoreFolderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CTCoreFolderTests.m; path = Tests/CTCoreFolderTests.m; sourceTree = "<group>"; };
 		F8EC5B0514C37F60006AF4D9 /* CTCoreFolderTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CTCoreFolderTests.h; path = Tests/CTCoreFolderTests.h; sourceTree = "<group>"; };
+		F9FC3A721683FC07004B2D1E /* TestData */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TestData; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -359,6 +361,7 @@
 				F888632D158102F50088CF38 /* Cyrus SASL.xcodeproj */,
 				F890D38D10CEECD50039817C /* libetpan.xcodeproj */,
 				F85A18AF09C7D8F200305C06 /* Tests */,
+				F9FC3A721683FC07004B2D1E /* TestData */,
 				08FB77AEFE84172EC02AAC07 /* Classes */,
 				32C88DFF0371C24200C91783 /* Other Sources */,
 				089C1665FE841158C02AAC07 /* Resources */,
@@ -784,6 +787,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8DFCF5615801A5000C01975 /* InfoPlist.strings in Resources */,
+				F9FC3A731683FC07004B2D1E /* TestData in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1033,6 +1037,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "libetpan/build-mac/include/**";
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				LIBRARY_SEARCH_PATHS = "";
 				SDKROOT = macosx;
 			};
@@ -1049,6 +1054,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "libetpan/build-mac/include/**";
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				LIBRARY_SEARCH_PATHS = "";
 				SDKROOT = macosx;
 			};
@@ -1111,7 +1117,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/iOSPorts/ports/security/cyrus-sasl/build/Debug-iphoneos\"",
@@ -1138,7 +1144,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/iOSPorts/ports/security/cyrus-sasl/build/Debug-iphoneos\"",

--- a/Source/CTCoreMessage.m
+++ b/Source/CTCoreMessage.m
@@ -177,6 +177,9 @@
 }
 
 - (NSString *)htmlBody {
+    if (myFields == NULL || myParsedMIME == nil) {
+        [self fetchBodyStructure];
+    }
     NSMutableString *result = [NSMutableString string];
     [self _buildUpHtmlBodyText:myParsedMIME result:result];
     return result;

--- a/Source/CTCoreMessage.m
+++ b/Source/CTCoreMessage.m
@@ -354,7 +354,7 @@
 
 - (NSDate *)senderDate {
     if ( myFields->fld_orig_date == NULL) {
-        return [NSDate distantPast];
+        return nil;
     } else {
         struct mailimf_date_time *d;
 

--- a/Tests/CTConnectedTest.h
+++ b/Tests/CTConnectedTest.h
@@ -38,4 +38,5 @@
 @interface CTConnectedTest : SenTestCase
 @property (nonatomic, strong) CTCoreAccount *account;
 @property (nonatomic, strong) CTCoreFolder  *folder;
+@property (nonatomic, strong) NSDictionary  *credentials;
 @end

--- a/Tests/CTCoreAttachmentTests.m
+++ b/Tests/CTCoreAttachmentTests.m
@@ -34,32 +34,32 @@
 
 @implementation CTCoreAttachmentTests
 - (void)testJPEG {
-	NSString *path = [NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/DSC_6201.jpg"];
-	CTCoreAttachment *attach = [[CTCoreAttachment alloc] initWithContentsOfFile:path];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/DSC_6201" ofType:@"jpg"];
+	CTCoreAttachment *attach = [[CTCoreAttachment alloc] initWithContentsOfFile:filePath];
 	STAssertEqualObjects(@"image/jpeg", [attach contentType], @"The content-type should have been image/jpeg");
 	STAssertTrue([attach data] != nil, @"Data should not have been nil");
 	[attach release];
 }
 
 - (void)testPNG {
-	NSString *path = [NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/DSC_6202.png"];
-	CTCoreAttachment *attach = [[CTCoreAttachment alloc] initWithContentsOfFile:path];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/DSC_6202" ofType:@"png"];
+	CTCoreAttachment *attach = [[CTCoreAttachment alloc] initWithContentsOfFile:filePath];
 	STAssertEqualObjects(@"image/png", [attach contentType], @"The content-type should have been image/png");
 	STAssertTrue([attach data] != nil, @"Data should not have been nil");
 	[attach release];
 }
 
 - (void)testTIFF {
-	NSString *path = [NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/DSC_6193.tif"];
-	CTCoreAttachment *attach = [[CTCoreAttachment alloc] initWithContentsOfFile:path];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/DSC_6193" ofType:@"tif"];
+	CTCoreAttachment *attach = [[CTCoreAttachment alloc] initWithContentsOfFile:filePath];
 	STAssertEqualObjects(@"image/tiff", [attach contentType], @"The content-type should have been image/TIFF");
 	STAssertTrue([attach data] != nil, @"Data should not have been nil");
 	[attach release];
 }
 
 - (void)testNEF {
-	NSString *path = [NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/DSC_6204.NEF"];
-	CTCoreAttachment *attach = [[CTCoreAttachment alloc] initWithContentsOfFile:path];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/DSC_6204" ofType:@"NEF"];
+	CTCoreAttachment *attach = [[CTCoreAttachment alloc] initWithContentsOfFile:filePath];
 	STAssertEqualObjects(@"application/octet-stream", [attach contentType], 
 		@"The content-type should have been application/octet-stream");
 	STAssertTrue([attach data] != nil, @"Data should not have been nil");

--- a/Tests/CTCoreFolderTests.m
+++ b/Tests/CTCoreFolderTests.m
@@ -43,7 +43,7 @@
     STAssertTrue([msg uid] > 0, @"We should have the UID");
     STAssertTrue([msg messageSize] > 0, @"We always download message size");
 
-    STAssertNil([msg sentDateGMT], @"We have no envelope so should be nil");
+    STAssertNil([msg senderDate], @"We have no envelope so should be nil");
     STAssertNil([msg subject], @"We have no envelope so should be nil");
     STAssertNil([msg to], @"We have no envelope so should be nil");
     STAssertNil([msg cc], @"We have no envelope so should be nil");
@@ -52,7 +52,7 @@
     STAssertNil([msg bcc], @"We have no envelope so should be nil");
 
     // This will force another download of message body data, checking to make sure it works
-    NSString *body = [msg bodyPreferringPlainText];
+    NSString *body = [msg body];
     STAssertTrue(body.length > 0, @"");
 }
 
@@ -63,14 +63,14 @@
     STAssertTrue([msg uid] > 0, @"We should have the UID");
     STAssertTrue([msg messageSize] > 0, @"We always download message size");
 
-    STAssertNotNil([msg sentDateGMT], @"We DO HAVE AN envelope so shouldn't be nil");
+    STAssertNotNil([msg senderDate], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg subject], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg to], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg sender], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg from], @"We DO HAVE AN envelope so shouldn't be nil");
 
     // This will force another download of message body data, checking to make sure it works
-    NSString *body = [msg bodyPreferringPlainText];
+    NSString *body = [msg body];
     STAssertTrue(body.length > 0, @"");
 }
 
@@ -81,14 +81,14 @@
     STAssertTrue([msg uid] > 0, @"We should have the UID");
     STAssertTrue([msg messageSize] > 0, @"We always download message size");
 
-    STAssertNotNil([msg sentDateGMT], @"We DO HAVE AN envelope so shouldn't be nil");
+    STAssertNotNil([msg senderDate], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg subject], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg to], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg sender], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg from], @"We DO HAVE AN envelope so shouldn't be nil");
 
     // This will force another download of message body data, checking to make sure it works
-    NSString *body = [msg bodyPreferringPlainText];
+    NSString *body = [msg body];
     STAssertTrue(body.length > 0, @"");
 }
 
@@ -99,7 +99,7 @@
     STAssertTrue([msg uid] > 0, @"We should have the UID");
     STAssertTrue([msg messageSize] > 0, @"We always download message size");
 
-    STAssertNil([msg sentDateGMT], @"We have no envelope so should be nil");
+    STAssertNil([msg senderDate], @"We have no envelope so should be nil");
     STAssertNil([msg subject], @"We have no envelope so should be nil");
     STAssertNil([msg to], @"We have no envelope so should be nil");
     STAssertNil([msg cc], @"We have no envelope so should be nil");
@@ -108,7 +108,7 @@
     STAssertNil([msg bcc], @"We have no envelope so should be nil");
 
     // A second call to fetch the body structure shouldn't be needed, we only need to fetch body
-    NSString *body = [msg bodyPreferringPlainText];
+    NSString *body = [msg body];
     STAssertTrue(body.length > 0, @"");
 }
 
@@ -119,14 +119,14 @@
     STAssertTrue([msg uid] > 0, @"We should have the UID");
     STAssertTrue([msg messageSize] > 0, @"We always download message size");
 
-    STAssertNotNil([msg sentDateGMT], @"We DO HAVE AN envelope so shouldn't be nil");
+    STAssertNotNil([msg senderDate], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg subject], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg to], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg sender], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg from], @"We DO HAVE AN envelope so shouldn't be nil");
 
     // A second call to fetch the body structure shouldn't be needed, we only need to fetch body
-    NSString *body = [msg bodyPreferringPlainText];
+    NSString *body = [msg body];
     STAssertTrue(body.length > 0, @"");
 }
 @end

--- a/Tests/CTCoreMessageTests.m
+++ b/Tests/CTCoreMessageTests.m
@@ -47,6 +47,16 @@
 	[myRealMsg release];
 }
 
+- (void)testBody {
+    STAssertTrue([[myRealMsg body] rangeOfString:@"Kiwi-dev mailing list"].location != NSNotFound, @"Expect to pull out the right text");
+    NSLog(@"Body is %@", [myRealMsg body]);
+}
+
+- (void)testHtmlBody {
+    STAssertTrue([[myRealMsg htmlBody] rangeOfString:@"CTCoreMessage no longer depends"].location != NSNotFound, @"Expect to pull out the right text");
+    NSLog(@"Html body is %@", [myRealMsg htmlBody]);
+}
+
 - (void)testBasicSubject {
 	[myMsg setSubject:@"Test value1!"];
 	STAssertEqualObjects(@"Test value1!", [myMsg subject], @"Basic set and get of subject failed.");

--- a/Tests/CTCoreMessageTests.m
+++ b/Tests/CTCoreMessageTests.m
@@ -38,7 +38,8 @@
 @implementation CTCoreMessageTests
 - (void)setUp {
 	myMsg = [[CTCoreMessage alloc] init];
-	myRealMsg = [[CTCoreMessage alloc] initWithFileAtPath:[NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/kiwi-dev/1167196014.6158_0.theronge.com:2,Sab"]];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/kiwi-dev/1167196014.6158_0.theronge.com:2,Sab" ofType:@""];
+	myRealMsg = [[CTCoreMessage alloc] initWithFileAtPath:filePath];
 }
 
 - (void)tearDown {
@@ -78,7 +79,8 @@
 }
 
 - (void)testSubjectOnData {
-	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:[NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/kiwi-dev/1167196014.6158_0.theronge.com:2,Sab"]];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/kiwi-dev/1167196014.6158_0.theronge.com:2,Sab" ofType:@""];
+    CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:filePath];
 	[msg fetchBodyStructure];
 	STAssertEqualObjects(@"[Kiwi-dev] Revision 16", [msg subject], @"");
 	NSRange notFound = NSMakeRange(NSNotFound, 0);
@@ -126,7 +128,8 @@
 }
 
 - (void)testFromSpecialChar {
-	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:[NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/kiwi-dev/1162094633.15211_0.randymail-mx2:2,RSab"]];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/kiwi-dev/1162094633.15211_0.randymail-mx2:2,RSab" ofType:@""];
+	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:filePath];
 	CTCoreAddress *addr = [[msg from] anyObject];
 	STAssertEqualObjects(@"Joachim Mårtensson", [addr name], @"");
 	[msg release];
@@ -152,10 +155,19 @@
 }
 
 - (void)testSentDate {
-    // Is this right?? I'm super confused by this time zone stuff
-	NSDate *sentDate = [myRealMsg sentDateGMT];
-	NSDate *actualDate = [NSDate dateWithTimeIntervalSince1970:1167217609];
-	STAssertEqualObjects(sentDate, actualDate, @"Date's should be equal!");
+    NSTimeInterval sentSince1970 = [[myRealMsg senderDate] timeIntervalSince1970];
+
+    NSTimeInterval actualSince1970 = 1167196009;
+    /*
+      you can get this value by typing this into your browser console
+
+      > date = new Date('Tue, 26 Dec 2006 21:06:49 -0800 (PST)')
+      Tue Dec 26 2006 21:06:49 GMT-0800 (PST)
+      > date.getTime() / 1000
+      1167196009
+    */
+
+    STAssertEquals(sentSince1970, actualSince1970, @"Dates should be equal!");
 }
 
 - (void)testSettingFromTwice {
@@ -166,16 +178,17 @@
 }
 
 - (void)testAttachments {
-	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:
-				[NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/mime-tests/png_attachment"]];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/mime-tests/png_attachment" ofType:@""];
+	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:filePath];
 	[msg fetchBodyStructure];
 	NSArray *attachments = [msg attachments];
 	STAssertTrue([attachments count] == 1, @"Count should have been 1");
 	STAssertEqualObjects([[attachments objectAtIndex:0] filename], @"Picture 1.png", @"Incorrect filename");
 	CTBareAttachment *bareAttach = [attachments objectAtIndex:0];
 	CTCoreAttachment *attach = [bareAttach fetchFullAttachment];
-	NSData *origData = [NSData dataWithContentsOfFile:
-						[NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/Picture 1.png"]];
+
+    filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/Picture 1" ofType:@"png"];
+	NSData *origData = [NSData dataWithContentsOfFile:filePath];
 	STAssertEqualObjects(origData, attach.data, @"Original data and attach data should be the same");
 	[msg release];
 }

--- a/Tests/CTCoreMessageTests.m
+++ b/Tests/CTCoreMessageTests.m
@@ -95,11 +95,11 @@
 	/* Do a few sanity checks on the str */
 	NSRange notFound = NSMakeRange(NSNotFound, 0);
 	STAssertTrue(!NSEqualRanges([str rangeOfString:@"Date:"],notFound), @"Render sanity check failed!");
-	STAssertTrue(!NSEqualRanges([str rangeOfString:@"Message-ID:"],notFound), @"Render sanity check failed!");	
-	STAssertTrue(!NSEqualRanges([str rangeOfString:@"MIME-Version: 1.0"],notFound), @"Render sanity check failed!");	
+	STAssertTrue(!NSEqualRanges([str rangeOfString:@"Message-ID:"],notFound), @"Render sanity check failed!");
+	STAssertTrue(!NSEqualRanges([str rangeOfString:@"MIME-Version: 1.0"],notFound), @"Render sanity check failed!");
 	STAssertTrue(!NSEqualRanges([str rangeOfString:@"test"],notFound), @"Render sanity check failed!");
-	STAssertTrue(!NSEqualRanges([str rangeOfString:@"Content-Transfer-Encoding:"],notFound), @"Render sanity check failed!");	
-	STAssertTrue(NSEqualRanges([str rangeOfString:@"not there"],notFound), @"Render sanity check failed!");	
+	STAssertTrue(!NSEqualRanges([str rangeOfString:@"Content-Transfer-Encoding:"],notFound), @"Render sanity check failed!");
+	STAssertTrue(NSEqualRanges([str rangeOfString:@"not there"],notFound), @"Render sanity check failed!");
 }
 
 - (void)testRenderWithToField {
@@ -110,7 +110,7 @@
 	/* Do a few sanity checks on the str */
 	NSRange notFound = NSMakeRange(NSNotFound, 0);
 	STAssertTrue(!NSEqualRanges([str rangeOfString:@"message"],notFound), @"Render sanity check failed!");
-	STAssertTrue(!NSEqualRanges([str rangeOfString:@"To: Matt <test@test.com>"],notFound), @"Render sanity check failed!");	
+	STAssertTrue(!NSEqualRanges([str rangeOfString:@"To: Matt <test@test.com>"],notFound), @"Render sanity check failed!");
 }
 
 - (void)testTo {

--- a/Tests/CTMIMETests.h
+++ b/Tests/CTMIMETests.h
@@ -31,8 +31,6 @@
 
 #import <SenTestingKit/SenTestingKit.h>
 
-const NSString *filePrefix;
-
 @interface CTMIMETests : SenTestCase {
 
 }

--- a/Tests/CTMIMETests.m
+++ b/Tests/CTMIMETests.m
@@ -41,11 +41,10 @@
 #import "CTMIME_TextPart.h"
 #import "CTMIME_Enumerator.h"
 
-const NSString *filePrefix = @"/Users/mronge/Projects/MailCore/";
-
 @implementation CTMIMETests
 - (void)testMIMETextPart {
-	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:[NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/kiwi-dev/1167196014.6158_0.theronge.com:2,Sab"]];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/kiwi-dev/1167196014.6158_0.theronge.com:2,Sab" ofType:@""];
+	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:filePath];
 	CTMIME *mime = [CTMIMEFactory createMIMEWithMIMEStruct:[msg messageStruct]->msg_mime forMessage:[msg messageStruct]];
 	STAssertTrue([mime isKindOfClass:[CTMIME_MessagePart class]],@"Outmost MIME type should be Message but it's not!");
 	STAssertTrue([[mime content] isKindOfClass:[CTMIME_MultiPart class]],@"Incorrect MIME structure found!");
@@ -85,7 +84,9 @@ const NSString *filePrefix = @"/Users/mronge/Projects/MailCore/";
 	while ((file = [dirEnumerator nextObject])) {
 		if (!NSEqualRanges([file rangeOfString:@".svn"],notFound))
 			continue;
-		CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:[NSString stringWithFormat:@"%@TestData/kiwi-dev/%@",filePrefix,file]];
+
+        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:[NSString stringWithFormat:@"TestData/kiwi-dev/%@",file] ofType:@""];
+		CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:filePath];
 		NSLog(@"%@", [msg subject]);
 		[msg fetchBodyStructure];
 		NSString *stuff = [msg body];
@@ -95,7 +96,9 @@ const NSString *filePrefix = @"/Users/mronge/Projects/MailCore/";
 }
 
 - (void)testImageJPEGAttachment {
-	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:[NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/mime-tests/imagetest"]];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/mime-tests/imagetest" ofType:@""];
+    CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:filePath];
+
 	CTMIME *mime = [CTMIMEFactory createMIMEWithMIMEStruct:[msg messageStruct]->msg_mime forMessage:[msg messageStruct]];
 	STAssertTrue([mime isKindOfClass:[CTMIME_MessagePart class]],@"Outmost MIME type should be Message but it's not!");
 	STAssertTrue([[mime content] isKindOfClass:[CTMIME_MultiPart class]],@"Incorrect MIME structure found!");
@@ -111,8 +114,9 @@ const NSString *filePrefix = @"/Users/mronge/Projects/MailCore/";
 }
 
 - (void)testImagePNGAttachment {
-	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:
-				[NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/mime-tests/png_attachment"]];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/mime-tests/png_attachment" ofType:@""];
+	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:filePath];
+
 	CTMIME *mime = [CTMIMEFactory createMIMEWithMIMEStruct:
 						[msg messageStruct]->msg_mime forMessage:[msg messageStruct]];
 	STAssertTrue([mime isKindOfClass:[CTMIME_MessagePart class]],
@@ -133,8 +137,9 @@ const NSString *filePrefix = @"/Users/mronge/Projects/MailCore/";
 }
 
 - (void)testEnumerator {
-	CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:
-				[NSString stringWithFormat:@"%@%@",filePrefix,@"TestData/mime-tests/png_attachment"]];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestData/mime-tests/png_attachment" ofType:@""];
+    CTCoreMessage *msg = [[CTCoreMessage alloc] initWithFileAtPath:filePath];
+
 	CTMIME *mime = [CTMIMEFactory createMIMEWithMIMEStruct:
 						[msg messageStruct]->msg_mime forMessage:[msg messageStruct]];
 	CTMIME_Enumerator *enumerator = [mime mimeEnumerator];

--- a/Tests/CTMIMETests.m
+++ b/Tests/CTMIMETests.m
@@ -78,10 +78,14 @@
 
 - (void)testBruteForce {
 	// run it on a bunch of the files in the test data directory and see if we can get it to crash
-	NSDirectoryEnumerator *dirEnumerator = [[NSFileManager defaultManager] enumeratorAtPath:[filePrefix stringByAppendingString:@"TestData/kiwi-dev/"]];
-	NSString *file;
+    NSString *directory = [[NSBundle bundleForClass:[self class]] resourcePath];
+    NSString *filesDirectory = [directory stringByAppendingPathComponent:@"TestData/kiwi-dev/"];
+
+    NSError *error;
+    NSArray *directoryContents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:filesDirectory error:&error];
+
 	NSRange notFound = NSMakeRange(NSNotFound, 0);
-	while ((file = [dirEnumerator nextObject])) {
+    for (NSString *file in directoryContents) {
 		if (!NSEqualRanges([file rangeOfString:@".svn"],notFound))
 			continue;
 


### PR DESCRIPTION
Hey guys. I'm back with an updated and cleaner Pull Request.

Now all TestData is compiled into the Test bundle and pulled out of it when needed by the tests. The same account.plist is still recommended (and excluded by .gitignore) to specify your own mail account information for the live test.

There was one key change to the source to make the tests pass, in commit 'Fix to Core Folder tests; senderDate returns nil.' Not sure why `[NSDate distantPast]` was used instead of nil, but I changed it to what the test expected, nil. We can easily change that back and in the test if needed. `[NSDate distantPast]` just seems very weird to me.

Three tests still failing, but they seem like they might be a regression in the core functionality more than anything specific to my changes. Thoughts?

> file://localhost/Users/scottnonnenberg/Development/MailCore/Tests/CTCoreAttachmentTests.m: error: testJPEG (CTCoreAttachmentTests) failed: 'image/jpeg' should be equal to 'application/octet-stream' The content-type should have been image/jpeg
> file://localhost/Users/scottnonnenberg/Development/MailCore/Tests/CTCoreAttachmentTests.m: error: testPNG (CTCoreAttachmentTests) failed: 'image/png' should be equal to 'application/octet-stream' The content-type should have been image/png
> file://localhost/Users/scottnonnenberg/Development/MailCore/Tests/CTCoreAttachmentTests.m: error: testTIFF (CTCoreAttachmentTests) failed: 'image/tiff' should be equal to 'application/octet-stream' The content-type should have been image/TIFF
