### PR TITLE
Fixed: Cannot set the folder's path.

### DIFF
--- a/Source/CTCoreFolder.m
+++ b/Source/CTCoreFolder.m
@@ -137,7 +137,7 @@ static const int MAX_PATH_SIZE = 1024;
     [self getUTF7String:newPath fromString:path];
     
     char oldPath[MAX_PATH_SIZE];
-    [self getUTF7String:newPath fromString:myPath];
+    [self getUTF7String:oldPath fromString:myPath];
     
     err =  mailimap_rename([myAccount session], oldPath, newPath);
     


### PR DESCRIPTION
We cannot set the new path for the IMAP core folder. I see that there is a bug in your code so I send this pull request for this fix.
