### PR TITLE
Support for get/set the extension flags for CTCoreMessage.

### DIFF
--- a/Source/CTCoreFolder.h
+++ b/Source/CTCoreFolder.h
@@ -213,6 +213,31 @@
 - (BOOL)setFlags:(NSUInteger)flags forMessage:(CTCoreMessage *)msg;
 
 /**
+ Retrieves the message extension flags.
+ @return Return YES on success, NO on error. Call method lastError to get error if one occurred
+ */
+- (BOOL)extensionFlagsForMessage:(CTCoreMessage *)msg flags:(NSArray **)flags;
+
+/**
+ Sets the message's extension flags on the server.
+ @return Return YES on success, NO on error. Call method lastError to get error if one occurred
+ */
+- (BOOL)setExtensionFlags:(NSArray *)flags forMessage:(CTCoreMessage *)msg;
+
+/**
+ Retrieves the message's flags and extension flags, take a look at the
+ documentation for flagsForMessage:
+ @return Return YES on success, NO on error. Call method lastError to get error if one occurred
+ */
+- (BOOL)flagsForMessage:(CTCoreMessage *)msg flags:(NSUInteger *)flags extensionFlags:(NSArray **)extensionFlags;
+
+/**
+ Sets the message's flags and extension flags on the server.
+ @return Return YES on success, NO on error. Call method lastError to get error if one occurred
+ */
+- (BOOL)setFlags:(NSUInteger)flags extensionFlags:(NSArray *)extensionFlags forMessage:(CTCoreMessage *)msg;
+
+/**
  Deletes all messages contained in the folder that are marked for
  deletion. Deleting messages in IMAP is a little strange, first
  you need to set the message flag CTFlagDeleted to CTFlagSet, and

--- a/Source/CTCoreFolder.m
+++ b/Source/CTCoreFolder.m
@@ -719,7 +719,7 @@ static const int MAX_PATH_SIZE = 1024;
     }
     
     int err;
-    clist *extensionFlags = clistFromStringArray(flags);
+    clist *extensionFlags = MailCoreClistFromStringArray(flags);
     if ([msg messageStruct]->msg_flags->fl_extension) {
         clist_free([msg messageStruct]->msg_flags->fl_extension);
         [msg messageStruct]->msg_flags->fl_extension = NULL;
@@ -756,7 +756,7 @@ static const int MAX_PATH_SIZE = 1024;
         *flags = flagStruct->fl_flags;
     }
     if (extensionFlags) {
-        NSArray *extionsionFlags = stringArrayFromClist(flagStruct->fl_extension);
+        NSArray *extionsionFlags = MailCoreStringArrayFromClist(flagStruct->fl_extension);
         *extensionFlags = extionsionFlags;
     }
     
@@ -771,7 +771,7 @@ static const int MAX_PATH_SIZE = 1024;
     
     int err;
     [msg messageStruct]->msg_flags->fl_flags = flags;
-    clist *extensions = clistFromStringArray(extensionFlags);
+    clist *extensions = MailCoreClistFromStringArray(extensionFlags);
     if ([msg messageStruct]->msg_flags->fl_extension) {
         clist_free([msg messageStruct]->msg_flags->fl_extension);
         [msg messageStruct]->msg_flags->fl_extension = NULL;

--- a/Source/CTCoreFolder.m
+++ b/Source/CTCoreFolder.m
@@ -683,21 +683,7 @@ static const int MAX_PATH_SIZE = 1024;
     already depends on CTCoreMessage so we aren't adding any dependencies here. */
 
 - (BOOL)flagsForMessage:(CTCoreMessage *)msg flags:(NSUInteger *)flags {
-    BOOL success = [self connect];
-    if (!success) {
-        return NO;
-    }
-
-    self.lastError = nil;
-    int err;
-    struct mail_flags *flagStruct;
-    err = mailmessage_get_flags([msg messageStruct], &flagStruct);
-    if (err != MAIL_NO_ERROR) {
-        self.lastError = MailCoreCreateErrorFromIMAPCode(err);
-        return NO;
-    }
-    *flags = flagStruct->fl_flags;
-    return YES;
+    return [self flagsForMessage:msg flags:flags extensionFlags:NULL];
 }
 
 
@@ -722,6 +708,87 @@ static const int MAX_PATH_SIZE = 1024;
     return YES;
 }
 
+- (BOOL)extensionFlagsForMessage:(CTCoreMessage *)msg flags:(NSArray **)flags {
+    return [self flagsForMessage:msg flags:NULL extensionFlags:flags];
+}
+
+- (BOOL)setExtensionFlags:(NSArray *)flags forMessage:(CTCoreMessage *)msg {
+    BOOL success = [self connect];
+    if (!success) {
+        return NO;
+    }
+    
+    int err;
+    clist *extensionFlags = clistFromStringArray(flags);
+    if ([msg messageStruct]->msg_flags->fl_extension) {
+        clist_free([msg messageStruct]->msg_flags->fl_extension);
+        [msg messageStruct]->msg_flags->fl_extension = NULL;
+    }
+    [msg messageStruct]->msg_flags->fl_extension = extensionFlags;
+    err = mailmessage_check([msg messageStruct]);
+    if (err != MAIL_NO_ERROR) {
+        self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+        return NO;
+    }
+    err = mailfolder_check(myFolder);
+    if (err != MAIL_NO_ERROR) {
+        self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+        return NO;
+    }
+    return YES;
+}
+
+- (BOOL)flagsForMessage:(CTCoreMessage *)msg flags:(NSUInteger *)flags extensionFlags:(NSArray **)extensionFlags {
+    BOOL success = [self connect];
+    if (!success) {
+        return NO;
+    }
+    
+    self.lastError = nil;
+    int err;
+    struct mail_flags *flagStruct;
+    err = mailmessage_get_flags([msg messageStruct], &flagStruct);
+    if (err != MAIL_NO_ERROR) {
+        self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+        return NO;
+    }
+    if (flags) {
+        *flags = flagStruct->fl_flags;
+    }
+    if (extensionFlags) {
+        NSArray *extionsionFlags = stringArrayFromClist(flagStruct->fl_extension);
+        *extensionFlags = extionsionFlags;
+    }
+    
+    return YES;
+}
+
+- (BOOL)setFlags:(NSUInteger)flags extensionFlags:(NSArray *)extensionFlags forMessage:(CTCoreMessage *)msg {
+    BOOL success = [self connect];
+    if (!success) {
+        return NO;
+    }
+    
+    int err;
+    [msg messageStruct]->msg_flags->fl_flags = flags;
+    clist *extensions = clistFromStringArray(extensionFlags);
+    if ([msg messageStruct]->msg_flags->fl_extension) {
+        clist_free([msg messageStruct]->msg_flags->fl_extension);
+        [msg messageStruct]->msg_flags->fl_extension = NULL;
+    }
+    [msg messageStruct]->msg_flags->fl_extension = extensions;
+    err = mailmessage_check([msg messageStruct]);
+    if (err != MAIL_NO_ERROR) {
+        self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+        return NO;
+    }
+    err = mailfolder_check(myFolder);
+    if (err != MAIL_NO_ERROR) {
+        self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+        return NO;
+    }
+    return YES;
+}
 
 - (BOOL)expunge {
     int err;
@@ -899,4 +966,6 @@ int uid_list_to_env_list(clist * fetch_result, struct mailmessage_list ** result
     err:
         return res;
 }
+
+
 @end

--- a/Source/CTCoreMessage.h
+++ b/Source/CTCoreMessage.h
@@ -208,6 +208,14 @@
 - (NSUInteger)flags;
 
 /**
+ Returns the message extionsion flags.
+ 
+ The extension flags contain flags other than standard flags in flags property. This include "Draft" flag.
+ See MailCoreTypes.h for a list of constants
+ */
+- (NSArray *)extionsionFlags;
+
+/**
  Set the message sequence number.
  
  This will NOT set any thing on the server.

--- a/Source/CTCoreMessage.m
+++ b/Source/CTCoreMessage.m
@@ -466,7 +466,7 @@
 
 - (NSArray *)extionsionFlags {
   if (myMessage != NULL && myMessage->msg_flags != NULL) {
-    return stringArrayFromClist(myMessage->msg_flags->fl_extension);
+    return MailCoreStringArrayFromClist(myMessage->msg_flags->fl_extension);
   }
   return nil;
 }
@@ -527,12 +527,12 @@
     if (myFields->fld_in_reply_to == NULL)
         return nil;
     else
-        return stringArrayFromClist(myFields->fld_in_reply_to->mid_list);
+        return MailCoreStringArrayFromClist(myFields->fld_in_reply_to->mid_list);
 }
 
 
 - (void)setInReplyTo:(NSArray *)messageIds {
-	struct mailimf_in_reply_to *imf = mailimf_in_reply_to_new(clistFromStringArray(messageIds));
+	struct mailimf_in_reply_to *imf = mailimf_in_reply_to_new(MailCoreClistFromStringArray(messageIds));
 
     if (myFields->fld_in_reply_to != NULL) {
         mailimf_in_reply_to_free(myFields->fld_in_reply_to);
@@ -547,12 +547,12 @@
     if (myFields->fld_references == NULL)
         return nil;
     else
-        return stringArrayFromClist(myFields->fld_references->mid_list);
+        return MailCoreStringArrayFromClist(myFields->fld_references->mid_list);
 }
 
 
 - (void)setReferences:(NSArray *)messageIds {
-    struct mailimf_references *imf = mailimf_references_new(clistFromStringArray(messageIds));
+    struct mailimf_references *imf = mailimf_references_new(MailCoreClistFromStringArray(messageIds));
 
     if (myFields->fld_references != NULL) {
         mailimf_references_free(myFields->fld_references);

--- a/Source/CTCoreMessage.m
+++ b/Source/CTCoreMessage.m
@@ -464,6 +464,13 @@
     return 0;
 }
 
+- (NSArray *)extionsionFlags {
+  if (myMessage != NULL && myMessage->msg_flags != NULL) {
+    return stringArrayFromClist(myMessage->msg_flags->fl_extension);
+  }
+  return nil;
+}
+
 - (NSUInteger)sequenceNumber {
     return mySequenceNumber;
 }
@@ -520,12 +527,12 @@
     if (myFields->fld_in_reply_to == NULL)
         return nil;
     else
-        return [self _stringArrayFromClist:myFields->fld_in_reply_to->mid_list];
+        return stringArrayFromClist(myFields->fld_in_reply_to->mid_list);
 }
 
 
 - (void)setInReplyTo:(NSArray *)messageIds {
-	struct mailimf_in_reply_to *imf = mailimf_in_reply_to_new([self _clistFromStringArray:messageIds]);
+	struct mailimf_in_reply_to *imf = mailimf_in_reply_to_new(clistFromStringArray(messageIds));
 
     if (myFields->fld_in_reply_to != NULL) {
         mailimf_in_reply_to_free(myFields->fld_in_reply_to);
@@ -540,12 +547,12 @@
     if (myFields->fld_references == NULL)
         return nil;
     else
-        return [self _stringArrayFromClist:myFields->fld_references->mid_list];
+        return stringArrayFromClist(myFields->fld_references->mid_list);
 }
 
 
 - (void)setReferences:(NSArray *)messageIds {
-    struct mailimf_references *imf = mailimf_references_new([self _clistFromStringArray:messageIds]);
+    struct mailimf_references *imf = mailimf_references_new(clistFromStringArray(messageIds));
 
     if (myFields->fld_references != NULL) {
         mailimf_references_free(myFields->fld_references);
@@ -816,32 +823,5 @@
     return imfList;
 }
 
-- (NSArray *)_stringArrayFromClist:(clist *)list {
-    clistiter *iter;
-    NSMutableArray *stringSet = [NSMutableArray array];
-	char *string;
-	
-    if(list == NULL)
-        return stringSet;
-	
-    for(iter = clist_begin(list); iter != NULL; iter = clist_next(iter)) {
-        string = clist_content(iter);
-        NSString *strObj = [[NSString alloc] initWithUTF8String:string];
-		[stringSet addObject:strObj];
-        [strObj release];
-    }
-	
-    return stringSet;
-}
-
-- (clist *)_clistFromStringArray:(NSArray *)strings {
-	clist * str_list = clist_new();
-
-	for (NSString *str in strings) {
-		clist_append(str_list, strdup([str UTF8String]));
-	}
-
-	return str_list;
-}
 
 @end

--- a/Source/MailCoreUtilities.h
+++ b/Source/MailCoreUtilities.h
@@ -51,3 +51,7 @@ NSError* MailCoreCreateErrorFromIMAPCode(int errcode);
 NSError* MailCoreCreateErrorFromSMTPCode(int errcode);
 
 NSString *MailCoreDecodeMIMEPhrase(char *data);
+
+NSArray * stringArrayFromClist(clist *list);
+clist *clistFromStringArray(NSArray *strings);
+

--- a/Source/MailCoreUtilities.h
+++ b/Source/MailCoreUtilities.h
@@ -52,6 +52,6 @@ NSError* MailCoreCreateErrorFromSMTPCode(int errcode);
 
 NSString *MailCoreDecodeMIMEPhrase(char *data);
 
-NSArray * stringArrayFromClist(clist *list);
-clist *clistFromStringArray(NSArray *strings);
+NSArray * MailCoreStringArrayFromClist(clist *list);
+clist *MailCoreClistFromStringArray(NSArray *strings);
 

--- a/Source/MailCoreUtilities.m
+++ b/Source/MailCoreUtilities.m
@@ -284,3 +284,31 @@ NSString *MailCoreDecodeMIMEPhrase(char *data) {
     free(decodedSubject);
     return result;
 }
+
+NSArray * stringArrayFromClist(clist *list) {
+  clistiter *iter;
+  NSMutableArray *stringSet = [NSMutableArray array];
+	char *string;
+	
+  if(list == NULL)
+    return stringSet;
+	
+  for(iter = clist_begin(list); iter != NULL; iter = clist_next(iter)) {
+    string = clist_content(iter);
+    NSString *strObj = [[NSString alloc] initWithUTF8String:string];
+    [stringSet addObject:strObj];
+    [strObj release];
+  }
+	
+  return stringSet;
+}
+
+clist *clistFromStringArray(NSArray *strings) {
+	clist * str_list = clist_new();
+  
+	for (NSString *str in strings) {
+		clist_append(str_list, strdup([str UTF8String]));
+	}
+  
+	return str_list;
+}

--- a/Source/MailCoreUtilities.m
+++ b/Source/MailCoreUtilities.m
@@ -285,7 +285,7 @@ NSString *MailCoreDecodeMIMEPhrase(char *data) {
     return result;
 }
 
-NSArray * stringArrayFromClist(clist *list) {
+NSArray * MailCoreStringArrayFromClist(clist *list) {
   clistiter *iter;
   NSMutableArray *stringSet = [NSMutableArray array];
 	char *string;
@@ -303,7 +303,7 @@ NSArray * stringArrayFromClist(clist *list) {
   return stringSet;
 }
 
-clist *clistFromStringArray(NSArray *strings) {
+clist *MailCoreClistFromStringArray(NSArray *strings) {
 	clist * str_list = clist_new();
   
 	for (NSString *str in strings) {


### PR DESCRIPTION
I have implemented the get/set extension flags for CTCoreMessage. The extension flags is array of flags others than the standard flag defined in the libetpan library including the "Draft" flag.

Please review my documentation in the CTCoreMessage and CTCoreFolder header files.
