### PR TITLE
Add Fetching mail with UID or Sequence number Index set.

### DIFF
--- a/Source/CTCoreFolder.h
+++ b/Source/CTCoreFolder.h
@@ -121,6 +121,35 @@
 */
 - (NSArray *)messagesFromUID:(NSUInteger)startUID to:(NSUInteger)endUID withFetchAttributes:(CTFetchAttributes)attrs;
 
+
+/**
+ Use this method to download message lists from the server.
+ 
+ This method uses sequence numbers indexset to determine which messages to download.
+ 
+ @param sequenceNumbers The indexset of sequence numbers to load.
+ @param attrs This controls what is fetched.
+ @return Returns a NSArray of CTCoreMessage's. Returns nil on error
+ @see messagesFromSequenceNumber:to:withFetchAttributes:
+ */
+- (NSArray *)messagesWithSequenceNumbers:(NSIndexSet *)sequenceNumbers
+                         fetchAttributes:(CTFetchAttributes)attrs;
+
+
+/**
+ Use this method to download message lists from the server.
+ 
+ This method uses uid numbers indexset to determine which messages to download.
+ 
+ @param uidNumbers The indexset of uid numbers to load.
+ @param attrs This controls what is fetched.
+ @return Returns a NSArray of CTCoreMessage's. Returns nil on error
+ @see messagesFromSequenceNumber:to:withFetchAttributes:
+ */
+- (NSArray *)messagesWithUIDs:(NSIndexSet *)uidNumbers
+              fetchAttributes:(CTFetchAttributes)attrs;
+
+
 /**
  Pulls the sequence number for the message with the specified uid.
  It does not perform UID validation, and the sequence ID is only

--- a/Source/CTCoreFolder.m
+++ b/Source/CTCoreFolder.m
@@ -641,6 +641,27 @@ static const int MAX_PATH_SIZE = 1024;
     return results;
 }
 
+- (NSArray *)messagesWithSequenceNumbers:(NSIndexSet *)sequenceNumbers
+                         fetchAttributes:(CTFetchAttributes)attrs {
+  struct mailimap_set *set = mailimap_set_new_empty();
+  [sequenceNumbers enumerateRangesUsingBlock:^(NSRange range, BOOL *stop) {
+    mailimap_set_add_interval(set, range.location, range.location + range.length - 1);
+  }];
+  
+  return [self messagesForSet:set fetchAttributes:attrs uidFetch:NO];
+  
+}
+
+- (NSArray *)messagesWithUIDs:(NSIndexSet *)uidNumbers
+              fetchAttributes:(CTFetchAttributes)attrs {
+  struct mailimap_set *set = mailimap_set_new_empty();
+  [uidNumbers enumerateRangesUsingBlock:^(NSRange range, BOOL *stop) {
+    mailimap_set_add_interval(set, range.location, range.location + range.length - 1);
+  }];
+  
+  return [self messagesForSet:set fetchAttributes:attrs uidFetch:YES];
+}
+
 - (CTCoreMessage *)messageWithUID:(NSUInteger)uid {
     int err;
     struct mailmessage *msgStruct;


### PR DESCRIPTION
In Cocoa ordered collection API. IndexSet is used for represented index of the data in ordered collection. So I think it would be great for add the fetch mail API that used IndexSet as the parameter.
