### PR TITLE
Add support for outgoing mail priority header.

### DIFF
--- a/Source/CTCoreMessage.h
+++ b/Source/CTCoreMessage.h
@@ -42,6 +42,13 @@
 
 @class CTCoreFolder, CTCoreAddress, CTCoreAttachment, CTMIME;
 
+typedef enum {
+    CTCoreMessageUrgentPriority = 1,
+    CTCoreMessageNormalPriority = 2,
+    CTCoreMessageNonUrgentPriority
+} CTCoreMessagePriority;
+
+
 @interface CTCoreMessage : NSObject {
     struct mailmessage *myMessage;
     struct mailimf_single_fields *myFields;
@@ -49,6 +56,7 @@
     NSUInteger mySequenceNumber;
     NSError *lastError;
     CTCoreFolder *parentFolder;
+    CTCoreMessagePriority mailPriority;
 }
 /**
  If an error occurred (nil or return of NO) call this method to get the error
@@ -325,6 +333,13 @@
  @return Return nil on error. Call method lastError to get error if one occurred
  */
 - (NSString *)rfc822Header;
+
+
+/**
+ Sets the outgoing message's priority header value.
+ Support for Mail Prioirty header defined in IMAP 4021 and X-Prioirty header.
+ */
+- (void)setMailPriority:(CTCoreMessagePriority)priority;
 
 /* Intended for advanced use only */
 - (struct mailmessage *)messageStruct;

--- a/Source/CTCoreMessage.m
+++ b/Source/CTCoreMessage.m
@@ -657,11 +657,16 @@
 
             struct mailimf_optional_field * priority = mailimf_optional_field_new("X-Priority", xPriorityValue);
             
-            struct mailimf_field * priorityField = mailimf_field_new(MAILIMF_FIELD_OPTIONAL_FIELD, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, priority);
+            struct mailimf_field * priorityField = mailimf_field_new(MAILIMF_FIELD_OPTIONAL_FIELD, NULL, NULL, NULL,
+                                                                     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                                                                     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                                                                     NULL, NULL, priority);
             mailimf_fields_add(fields, priorityField);
             
             priority = mailimf_optional_field_new("Priority", rfcPriorityValue);
-            priorityField = mailimf_field_new(MAILIMF_FIELD_OPTIONAL_FIELD, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, priority);
+            priorityField = mailimf_field_new(MAILIMF_FIELD_OPTIONAL_FIELD, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                                              NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                                              NULL, NULL, priority);
             
             mailimf_fields_add(fields, priorityField);
         }
@@ -736,7 +741,7 @@
 }
 
 - (void)setMailPriority:(CTCoreMessagePriority)priority {
-    self->mailPriority = priority;
+    mailPriority = priority;
 }
 
 - (struct mailmessage *)messageStruct {

--- a/Source/CTCoreMessage.m
+++ b/Source/CTCoreMessage.m
@@ -629,9 +629,44 @@
         clist *references = (myFields->fld_references != NULL) ? (myFields->fld_references->mid_list) : NULL;
         char *subject = (myFields->fld_subject != NULL) ? (myFields->fld_subject->sbj_value) : NULL;
 
+        fields = mailimf_fields_new_with_data(from, sender, replyTo, to, cc, bcc, inReplyTo, references, subject);
+        
+        if (self->mailPriority != 0) {
+            char * xPriorityValue;
+            char * rfcPriorityValue;
+            switch (self->mailPriority) {
+                case CTCoreMessageUrgentPriority: {
+                    xPriorityValue = "1";
+                    rfcPriorityValue = "urgent";
+                    break;
+                }
+                case CTCoreMessageNormalPriority: {
+                    xPriorityValue = "3";
+                    rfcPriorityValue = "normal";
+                    break;
+                }
+                case CTCoreMessageNonUrgentPriority: {
+                    xPriorityValue = "5";
+                    rfcPriorityValue = "non-urgent";
+                    break;
+                }
+                    
+                default:
+                    break;
+            }
+
+            struct mailimf_optional_field * priority = mailimf_optional_field_new("X-Priority", xPriorityValue);
+            
+            struct mailimf_field * priorityField = mailimf_field_new(MAILIMF_FIELD_OPTIONAL_FIELD, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, priority);
+            mailimf_fields_add(fields, priorityField);
+            
+            priority = mailimf_optional_field_new("Priority", rfcPriorityValue);
+            priorityField = mailimf_field_new(MAILIMF_FIELD_OPTIONAL_FIELD, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, priority);
+            
+            mailimf_fields_add(fields, priorityField);
+        }
         //TODO uh oh, when this get freed it frees stuff in the CTCoreMessage
         //TODO Need to make sure that fields gets freed somewhere
-        fields = mailimf_fields_new_with_data(from, sender, replyTo, to, cc, bcc, inReplyTo, references, subject);
         [(CTMIME_MessagePart *)msgPart setIMFFields:fields];
     }
     return [myParsedMIME render];
@@ -698,6 +733,10 @@
     }
     mailimap_msg_att_rfc822_free(result);
     return [nsresult autorelease];
+}
+
+- (void)setMailPriority:(CTCoreMessagePriority)priority {
+    self->mailPriority = priority;
 }
 
 - (struct mailmessage *)messageStruct {


### PR DESCRIPTION
Mail priority header is defined in IMAP RFC 4021. This pull request add support for setting the mail priority header in the outgoing message.
