### PR TITLE
Parse the filename to the attached text or eml attachments.

### DIFF
--- a/Source/CTMIME_MessagePart.h
+++ b/Source/CTMIME_MessagePart.h
@@ -36,7 +36,12 @@
 @interface CTMIME_MessagePart : CTMIME {
     CTMIME *myMessageContent;
     struct mailimf_fields *myFields;
+    NSDictionary *myRFC822Headers;
 }
+
+@property (nonatomic, copy) NSString *filename;
+@property (nonatomic, readonly) NSDictionary *rfc822Headers;
+
 + (id)mimeMessagePartWithContent:(CTMIME *)mime;
 - (id)initWithContent:(CTMIME *)messageContent;
 - (void)setContent:(CTMIME *)aContent;

--- a/Source/CTMIME_MessagePart.m
+++ b/Source/CTMIME_MessagePart.m
@@ -150,7 +150,9 @@
                                                          forMessage:message] retain];
         myFields = mime->mm_data.mm_message.mm_fields;
         
-        self.filename = MailCoreGetFileNameFromMIME(mime);
+        if (mime->mm_parent_type == MAILMIME_MULTIPLE) {
+            self.filename = MailCoreGetEMLFileNameFromMIME(mime);
+        }
     }
     return self;
 }

--- a/Source/CTMIME_MessagePart.m
+++ b/Source/CTMIME_MessagePart.m
@@ -34,8 +34,109 @@
 #import <libetpan/libetpan.h>
 #import "MailCoreTypes.h"
 #import "CTMIMEFactory.h"
+#import "MailCoreUtilities.h"
 
 @implementation CTMIME_MessagePart
+
+@synthesize rfc822Headers = myRFC822Headers;
+
+- (NSDictionary *)rfc822Headers {
+    if (!myRFC822Headers) {
+        NSMutableDictionary *rfc822Headers = nil;
+        if (myFields && myFields->fld_list) {
+            rfc822Headers = [[NSMutableDictionary alloc] initWithCapacity:myFields->fld_list->count];
+            clistiter *iter = NULL;
+            clist * headers = myFields->fld_list;
+            
+            for (iter = clist_begin(headers); iter != NULL; iter = clist_next(iter)) {
+                struct mailimf_field * field = clist_content(iter);
+                
+                switch (field->fld_type) {
+                    case MAILIMF_FIELD_SUBJECT:
+                        rfc822Headers[@"Subject"] = [NSString stringWithUTF8String:field->fld_data.fld_subject->sbj_value];
+                        break;
+                    case MAILIMF_FIELD_MESSAGE_ID:
+                        rfc822Headers[@"Message-ID"] = [NSString stringWithUTF8String:field->fld_data.fld_message_id->mid_value];
+                        break;
+                    case MAILIMF_FIELD_SENDER:
+                        rfc822Headers[@"Sender"] = MailCoreAddressRepresentationFromMailBox(field->fld_data.fld_sender->snd_mb);
+                        break;
+                    case MAILIMF_FIELD_FROM:
+                        rfc822Headers[@"From"] = MailCoreAddressRepresentationArrayFromMailBoxClist(field->fld_data.fld_from->frm_mb_list->mb_list);
+                        break;
+                    case MAILIMF_FIELD_TO:
+                        rfc822Headers[@"To"] = MailCoreAddressRepresentationArrayFromAddressClist(field->fld_data.fld_to->to_addr_list->ad_list);
+                        break;
+                    case MAILIMF_FIELD_CC:
+                        rfc822Headers[@"CC"] = MailCoreAddressRepresentationArrayFromAddressClist(field->fld_data.fld_cc->cc_addr_list->ad_list);
+                        break;
+                    case MAILIMF_FIELD_BCC:
+                        rfc822Headers[@"BCC"] = MailCoreAddressRepresentationArrayFromAddressClist(field->fld_data.fld_bcc->bcc_addr_list->ad_list);
+                        break;
+                    case MAILIMF_FIELD_REPLY_TO:
+                        rfc822Headers[@"Reply-To"] = MailCoreAddressRepresentationArrayFromAddressClist(field->fld_data.fld_reply_to->rt_addr_list->ad_list);
+                        break;
+                    case MAILIMF_FIELD_IN_REPLY_TO:
+                        rfc822Headers[@"In-Reply-To"] = MailCoreStringArrayFromClist(field->fld_data.fld_in_reply_to->mid_list);
+                        break;
+                    case MAILIMF_FIELD_REFERENCES:
+                        rfc822Headers[@"References"] = MailCoreStringArrayFromClist(field->fld_data.fld_references->mid_list);
+                        break;
+                    case MAILIMF_FIELD_ORIG_DATE:
+                        rfc822Headers[@"Date"] = MailCoreDateFromMailIMAPDateTime(field->fld_data.fld_orig_date->dt_date_time);
+                        break;
+                    case MAILIMF_FIELD_RESENT_MSG_ID:
+                        rfc822Headers[@"Recent-Message-ID"] = [NSString stringWithUTF8String:field->fld_data.fld_resent_msg_id->mid_value];
+                        break;
+                    case MAILIMF_FIELD_RESENT_SENDER:
+                        rfc822Headers[@"Resent-Sender"] = MailCoreAddressRepresentationFromMailBox(field->fld_data.fld_resent_sender->snd_mb);
+                        break;
+                    case MAILIMF_FIELD_RESENT_FROM:
+                        rfc822Headers[@"Resent-From"] = MailCoreAddressRepresentationArrayFromMailBoxClist(field->fld_data.fld_resent_from->frm_mb_list->mb_list);
+                        break;
+                    case MAILIMF_FIELD_RESENT_TO:
+                        rfc822Headers[@"Resent-To"] = MailCoreAddressRepresentationArrayFromAddressClist(field->fld_data.fld_resent_to->to_addr_list->ad_list);
+                        break;
+                    case MAILIMF_FIELD_RESENT_CC:
+                        rfc822Headers[@"Resent-CC"] = MailCoreAddressRepresentationArrayFromAddressClist(field->fld_data.fld_resent_cc->cc_addr_list->ad_list);
+                        break;
+                    case MAILIMF_FIELD_RESENT_BCC:
+                        rfc822Headers[@"Resent-BCC"] = MailCoreAddressRepresentationArrayFromAddressClist(field->fld_data.fld_resent_bcc->bcc_addr_list->ad_list);
+                        break;
+                    case MAILIMF_FIELD_RESENT_DATE:
+                        rfc822Headers[@"Resent-Date"] = MailCoreDateFromMailIMAPDateTime(field->fld_data.fld_resent_date->dt_date_time);
+                        break;
+                        
+                    case MAILIMF_FIELD_RETURN_PATH:
+                        rfc822Headers[@"Return-Path"] = [NSString stringWithUTF8String:field->fld_data.fld_return_path->ret_path->pt_addr_spec];
+                        break;
+                        
+                    case MAILIMF_FIELD_KEYWORDS:
+                        rfc822Headers[@"Keywords"] = MailCoreStringArrayFromClist(field->fld_data.fld_keywords->kw_list);
+                        break;
+                    case MAILIMF_FIELD_COMMENTS:
+                        rfc822Headers[@"Comments"] = [NSString stringWithUTF8String:field->fld_data.fld_comments->cm_value];
+                        break;
+                    case MAILIMF_FIELD_OPTIONAL_FIELD: {
+                        NSString *fieldname = [NSString stringWithUTF8String:field->fld_data.fld_optional_field->fld_name];
+                        NSString *fieldValue = [NSString stringWithUTF8String:field->fld_data.fld_optional_field->fld_value];
+                        if (fieldname && fieldValue) {
+                            rfc822Headers[fieldname] = fieldValue;
+                        }
+                    }
+                        
+                    default:
+                        break;
+                }
+            }
+        }
+        
+        myRFC822Headers = [rfc822Headers ?: @{} copy];
+    }
+    
+    return myRFC822Headers;
+}
+
 + (id)mimeMessagePartWithContent:(CTMIME *)mime {
     return [[[CTMIME_MessagePart alloc] initWithContent:mime] autorelease];
 }
@@ -48,6 +149,8 @@
         myMessageContent = [[CTMIMEFactory createMIMEWithMIMEStruct:content
                                                          forMessage:message] retain];
         myFields = mime->mm_data.mm_message.mm_fields;
+        
+        self.filename = MailCoreGetFileNameFromMIME(mime);
     }
     return self;
 }

--- a/Source/CTMIME_SinglePart.h
+++ b/Source/CTMIME_SinglePart.h
@@ -34,6 +34,13 @@
 
 typedef void (^CTProgressBlock)(size_t curr, size_t max);
 
+typedef NS_OPTIONS(NSUInteger, CTMIMEAttachmentType) {
+  CTMIMEAttachmentNonType = 0,
+  CTMIMEAttachmentAttachedType = 1 << 0,
+  CTMIMEAttachmentInlineType = 1 << 1
+};
+
+
 @interface CTMIME_SinglePart : CTMIME {
     struct mailmime *mMime;
     struct mailmessage *mMessage;
@@ -41,17 +48,20 @@ typedef void (^CTProgressBlock)(size_t curr, size_t max);
 
     NSData *mData;
     BOOL mAttached;
+    BOOL mInlined;
     BOOL mFetched;
     NSString *mFilename;
     NSString *mContentId;
     NSError *lastError;
 }
 @property(nonatomic) BOOL attached;
+@property(nonatomic, getter = isInlined) BOOL inlined;
 @property(nonatomic) BOOL fetched;
 @property(nonatomic, retain) NSString *filename;
 @property(nonatomic, retain) NSString *contentId;
 @property(nonatomic, retain) NSData *data;
 @property(nonatomic, readonly) size_t size;
+@property(nonatomic, readonly) CTMIMEAttachmentType attachmentType;
 
 /*
  If an error occurred (nil or return of NO) call this method to get the error

--- a/Source/MailCoreUtilities.h
+++ b/Source/MailCoreUtilities.h
@@ -50,8 +50,23 @@ NSError* MailCoreCreateErrorFromIMAPCode(int errcode);
 */
 NSError* MailCoreCreateErrorFromSMTPCode(int errcode);
 
-NSString *MailCoreDecodeMIMEPhrase(char *data);
+NSString *MailCoreDecodeMIMEPhrase(const char *data);
+
+NSString *MailCoreGetFileNameFromMIME(struct mailmime * mime);
+NSString *MailCoreGetFileNameFromMIMEFields(struct mailmime_single_fields * mime);
+
+NSDictionary * MailCoreAddressRepresentationFromMailBox(struct mailimf_mailbox *mailbox);
+NSDictionary * MailCoreAddressRepresentationFromAddress(struct mailimf_address *mailbox);
+NSDictionary * MailCoreAddressRepresentationFromGroup(struct mailimf_group *group);
+NSArray * MailCoreAddressRepresentationArrayFromMailBoxClist(clist *list);
+NSArray * MailCoreAddressRepresentationArrayFromAddressClist(clist *list);
 
 NSArray * MailCoreStringArrayFromClist(clist *list);
 clist *MailCoreClistFromStringArray(NSArray *strings);
+
+NSDate * MailCoreDateFromMailIMAPDateTime(struct mailimf_date_time * datetime);
+NSTimeZone * MailCoreTimeZoneFromDTTimeZone(int timezone);
+
+struct mailimap_date * mailimap_dateFromDate(NSDate *date);
+struct mailimap_date * mailimap_dateFromDateComponents(NSDateComponents *dateComponents);
 

--- a/Source/MailCoreUtilities.h
+++ b/Source/MailCoreUtilities.h
@@ -54,6 +54,7 @@ NSString *MailCoreDecodeMIMEPhrase(const char *data);
 
 NSString *MailCoreGetFileNameFromMIME(struct mailmime * mime);
 NSString *MailCoreGetFileNameFromMIMEFields(struct mailmime_single_fields * mime);
+NSString *MailCoreGetEMLFileNameFromMIME(struct mailmime * mime);
 
 NSDictionary * MailCoreAddressRepresentationFromMailBox(struct mailimf_mailbox *mailbox);
 NSDictionary * MailCoreAddressRepresentationFromAddress(struct mailimf_address *mailbox);

--- a/Source/MailCoreUtilities.m
+++ b/Source/MailCoreUtilities.m
@@ -266,11 +266,11 @@ NSString *MailCoreDecodeMIMEPhrase(const char *data) {
     size_t currToken = 0;
     char *decodedSubject;
     NSString *result;
-
+    
     if (data && *data != '\0') {
         err = mailmime_encoded_phrase_parse(DEST_CHARSET, data, strlen(data),
                                             &currToken, DEST_CHARSET, &decodedSubject);
-
+        
         if (err != MAILIMF_NO_ERROR) {
             if (decodedSubject == NULL)
                 free(decodedSubject);
@@ -279,181 +279,206 @@ NSString *MailCoreDecodeMIMEPhrase(const char *data) {
     } else {
         return @"";
     }
-
+    
     result = [NSString stringWithCString:decodedSubject encoding:NSUTF8StringEncoding];
     free(decodedSubject);
     return result;
 }
 
 NSString *MailCoreGetFileNameFromMIME(struct mailmime * mime) {
-  NSString *filename = nil;
-  struct mailmime_single_fields * mimeFields = mailmime_single_fields_new(mime->mm_mime_fields, mime->mm_content_type);
-  
-  if (mimeFields) {
-    filename = MailCoreGetFileNameFromMIMEFields(mimeFields);
+    NSString *filename = nil;
+    struct mailmime_single_fields * mimeFields = mailmime_single_fields_new(mime->mm_mime_fields, mime->mm_content_type);
     
-    mailmime_single_fields_free(mimeFields);
-  }
-  
-  return filename;
+    if (mimeFields) {
+        filename = MailCoreGetFileNameFromMIMEFields(mimeFields);
+        
+        mailmime_single_fields_free(mimeFields);
+    }
+    
+    return filename;
 }
 
 NSString *MailCoreGetFileNameFromMIMEFields(struct mailmime_single_fields * mimeFields) {
-  NSString *filename = nil;
-  char * rawFilename = NULL;
-  if (mimeFields->fld_disposition_filename) {
-    rawFilename = mimeFields->fld_disposition_filename;
-  } else if (mimeFields->fld_content_name) {
-    rawFilename = mimeFields->fld_content_name;
-  }
-  
-  if (rawFilename) {
-    filename = [NSString stringWithCString:rawFilename
-                                  encoding:NSUTF8StringEncoding];
-    
-    // Check for RFC-2047 encoded filename
-    if ([filename hasPrefix:@"=?"] &&
-        [filename hasSuffix:@"?="]) {
-      filename = MailCoreDecodeMIMEPhrase([filename UTF8String]);
+    NSString *filename = nil;
+    char * rawFilename = NULL;
+    if (mimeFields->fld_disposition_filename) {
+        rawFilename = mimeFields->fld_disposition_filename;
+    } else if (mimeFields->fld_content_name) {
+        rawFilename = mimeFields->fld_content_name;
     }
-  }
-  
-  return filename;
+    
+    if (rawFilename) {
+        filename = [NSString stringWithCString:rawFilename
+                                      encoding:NSUTF8StringEncoding];
+        
+        // Check for RFC-2047 encoded filename
+        if ([filename hasPrefix:@"=?"] &&
+            [filename hasSuffix:@"?="]) {
+            filename = MailCoreDecodeMIMEPhrase([filename UTF8String]);
+        }
+    }
+    
+    return filename;
+}
+
+NSString *MailCoreGetEMLFileNameFromMIME(struct mailmime * mime) {
+    NSString *filename = MailCoreGetFileNameFromMIME(mime);
+    if (!filename) {
+        struct mailmime *parentMime = mime->mm_parent;
+        // If the parent mime is the report subtype, we will use the content description as the eml file name.
+        if (parentMime && mime->mm_parent_type == MAILMIME_MULTIPLE &&
+            strcasecmp(mime->mm_content_type->ct_subtype, "REPORT") &&
+            mime->mm_mime_fields && mime->mm_mime_fields->fld_list) {
+            
+            clistiter *iter;
+            struct mailmime_field *field;
+            
+            for (iter = clist_begin(mime->mm_mime_fields->fld_list); iter != NULL; iter = clist_next(iter)) {
+                field = clist_content(iter);
+                if (field->fld_type == MAILMIME_FIELD_DESCRIPTION) {
+                    filename = [[NSString stringWithUTF8String:field->fld_data.fld_description] stringByAppendingPathExtension:@"eml"];
+                    break;
+                }
+            }
+        }
+    }
+    
+    return filename;
 }
 
 NSDictionary * MailCoreAddressRepresentationFromMailBox(struct mailimf_mailbox *mailbox) {
-  NSMutableDictionary *address = [NSMutableDictionary dictionaryWithCapacity:2];
-  address[@"email"] = [NSString stringWithUTF8String:mailbox->mb_addr_spec];
-  if (mailbox->mb_display_name) {
-    address[@"name"] = [NSString stringWithUTF8String:mailbox->mb_display_name];
-  }
-  
-  return [[address copy] autorelease];
+    NSMutableDictionary *address = [NSMutableDictionary dictionaryWithCapacity:2];
+    address[@"email"] = [NSString stringWithUTF8String:mailbox->mb_addr_spec];
+    if (mailbox->mb_display_name) {
+        address[@"name"] = [NSString stringWithUTF8String:mailbox->mb_display_name];
+    }
+    
+    return [[address copy] autorelease];
 }
 
 NSDictionary * MailCoreAddressRepresentationFromGroup(struct mailimf_group *group) {
-  NSMutableDictionary *address = [NSMutableDictionary dictionaryWithCapacity:2];
-  address[@"groupname"] = [NSString stringWithUTF8String:group->grp_display_name];
-  if (group->grp_mb_list) {
-    address[@"addresses"] = MailCoreAddressRepresentationArrayFromMailBoxClist(group->grp_mb_list->mb_list);
-  }
-  
-  return [[address copy] autorelease];
+    NSMutableDictionary *address = [NSMutableDictionary dictionaryWithCapacity:2];
+    address[@"groupname"] = [NSString stringWithUTF8String:group->grp_display_name];
+    if (group->grp_mb_list) {
+        address[@"addresses"] = MailCoreAddressRepresentationArrayFromMailBoxClist(group->grp_mb_list->mb_list);
+    }
+    
+    return [[address copy] autorelease];
 }
 
 NSDictionary * MailCoreAddressRepresentationFromAddress(struct mailimf_address *address) {
-  NSDictionary *addressRepresentation = nil;
-  if (address->ad_type == MAILIMF_ADDRESS_MAILBOX) {
-    addressRepresentation = MailCoreAddressRepresentationFromMailBox(address->ad_data.ad_mailbox);
-  } else if (address->ad_type == MAILIMF_ADDRESS_GROUP) {
-    addressRepresentation = MailCoreAddressRepresentationFromGroup(address->ad_data.ad_group);
-  }
-  
-  return addressRepresentation;
+    NSDictionary *addressRepresentation = nil;
+    if (address->ad_type == MAILIMF_ADDRESS_MAILBOX) {
+        addressRepresentation = MailCoreAddressRepresentationFromMailBox(address->ad_data.ad_mailbox);
+    } else if (address->ad_type == MAILIMF_ADDRESS_GROUP) {
+        addressRepresentation = MailCoreAddressRepresentationFromGroup(address->ad_data.ad_group);
+    }
+    
+    return addressRepresentation;
 }
 
 NSArray * MailCoreAddressRepresentationArrayFromMailBoxClist(clist *list) {
-  clistiter *iter;
-  NSMutableArray *addresses = [NSMutableArray array];
+    clistiter *iter;
+    NSMutableArray *addresses = [NSMutableArray array];
 	struct mailimf_mailbox *mailbox;
 	
-  if (list == NULL)
-    return addresses;
+    if (list == NULL)
+        return addresses;
 	
-  for (iter = clist_begin(list); iter != NULL; iter = clist_next(iter)) {
-    mailbox = clist_content(iter);
-    NSDictionary *address = MailCoreAddressRepresentationFromMailBox(mailbox);
-    [addresses addObject:address];
-  }
+    for (iter = clist_begin(list); iter != NULL; iter = clist_next(iter)) {
+        mailbox = clist_content(iter);
+        NSDictionary *address = MailCoreAddressRepresentationFromMailBox(mailbox);
+        [addresses addObject:address];
+    }
 	
-  return [addresses copy];
+    return [addresses copy];
 }
 
 NSArray * MailCoreAddressRepresentationArrayFromAddressClist(clist *list) {
-  clistiter *iter;
-  NSMutableArray *addresses = [NSMutableArray array];
+    clistiter *iter;
+    NSMutableArray *addresses = [NSMutableArray array];
 	struct mailimf_address *address;
 	
-  if (list == NULL)
-    return addresses;
+    if (list == NULL)
+        return addresses;
 	
-  for (iter = clist_begin(list); iter != NULL; iter = clist_next(iter)) {
-    address = clist_content(iter);
-    NSDictionary *addressRepresentation = MailCoreAddressRepresentationFromAddress(address);
-    [addresses addObject:addressRepresentation];
-  }
+    for (iter = clist_begin(list); iter != NULL; iter = clist_next(iter)) {
+        address = clist_content(iter);
+        NSDictionary *addressRepresentation = MailCoreAddressRepresentationFromAddress(address);
+        [addresses addObject:addressRepresentation];
+    }
 	
-  return [addresses copy];
+    return [addresses copy];
 }
 
 NSArray * MailCoreStringArrayFromClist(clist *list) {
-  clistiter *iter;
-  NSMutableArray *stringSet = [NSMutableArray array];
+    clistiter *iter;
+    NSMutableArray *stringSet = [NSMutableArray array];
 	char *string;
 	
-  if(list == NULL)
+    if(list == NULL)
+        return stringSet;
+	
+    for(iter = clist_begin(list); iter != NULL; iter = clist_next(iter)) {
+        string = clist_content(iter);
+        NSString *strObj = [[NSString alloc] initWithUTF8String:string];
+        [stringSet addObject:strObj];
+        [strObj release];
+    }
+	
     return stringSet;
-	
-  for(iter = clist_begin(list); iter != NULL; iter = clist_next(iter)) {
-    string = clist_content(iter);
-    NSString *strObj = [[NSString alloc] initWithUTF8String:string];
-    [stringSet addObject:strObj];
-    [strObj release];
-  }
-	
-  return stringSet;
 }
 
 clist *MailCoreClistFromStringArray(NSArray *strings) {
 	clist * str_list = clist_new();
-  
+    
 	for (NSString *str in strings) {
 		clist_append(str_list, strdup([str UTF8String]));
 	}
-  
+    
 	return str_list;
 }
 
 NSDate * MailCoreDateFromMailIMAPDateTime(struct mailimf_date_time * datetime) {
-  static NSCalendar *calendar;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-  });
-  
-  NSDateComponents *component = [[NSDateComponents alloc] init];
-  component.day = datetime->dt_day;
-  component.month = datetime->dt_month;
-  component.year = datetime->dt_year;
-  component.hour = datetime->dt_hour;
-  component.minute = datetime->dt_min;
-  component.second = datetime->dt_sec;
-  component.day = datetime->dt_day;
-  component.timeZone = MailCoreTimeZoneFromDTTimeZone(datetime->dt_zone);
-  
-  return [calendar dateFromComponents:component];
+    static NSCalendar *calendar;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+    });
+    
+    NSDateComponents *component = [[NSDateComponents alloc] init];
+    component.day = datetime->dt_day;
+    component.month = datetime->dt_month;
+    component.year = datetime->dt_year;
+    component.hour = datetime->dt_hour;
+    component.minute = datetime->dt_min;
+    component.second = datetime->dt_sec;
+    component.day = datetime->dt_day;
+    component.timeZone = MailCoreTimeZoneFromDTTimeZone(datetime->dt_zone);
+    
+    return [calendar dateFromComponents:component];
 }
 
 NSTimeZone * MailCoreTimeZoneFromDTTimeZone(int timezone) {
-  NSInteger hour = timezone / 100;
-  NSInteger minute = timezone % 100;
-  
-  
-  return [NSTimeZone timeZoneForSecondsFromGMT:(hour * 3600) + (minute * 60)];
+    NSInteger hour = timezone / 100;
+    NSInteger minute = timezone % 100;
+    
+    
+    return [NSTimeZone timeZoneForSecondsFromGMT:(hour * 3600) + (minute * 60)];
 }
 
 struct mailimap_date * mailimap_dateFromDate(NSDate *date) {
-  static NSCalendar *calendar;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-  });
-  
-  return mailimap_dateFromDateComponents([calendar components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit)
-                                                     fromDate:date]);
+    static NSCalendar *calendar;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+    });
+    
+    return mailimap_dateFromDateComponents([calendar components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit)
+                                                       fromDate:date]);
 }
 
 struct mailimap_date * mailimap_dateFromDateComponents(NSDateComponents *dateComponents) {
-  return mailimap_date_new(dateComponents.day, dateComponents.month, dateComponents.year);
+    return mailimap_date_new(dateComponents.day, dateComponents.month, dateComponents.year);
 }
 

--- a/Source/MailCoreUtilities.m
+++ b/Source/MailCoreUtilities.m
@@ -327,7 +327,7 @@ NSString *MailCoreGetEMLFileNameFromMIME(struct mailmime * mime) {
         struct mailmime *parentMime = mime->mm_parent;
         // If the parent mime is the report subtype, we will use the content description as the eml file name.
         if (parentMime && mime->mm_parent_type == MAILMIME_MULTIPLE &&
-            strcasecmp(mime->mm_content_type->ct_subtype, "REPORT") &&
+            strcasecmp(parentMime->mm_content_type->ct_subtype, "REPORT") == 0 &&
             mime->mm_mime_fields && mime->mm_mime_fields->fld_list) {
             
             clistiter *iter;


### PR DESCRIPTION
When the eml file is attached to the mail. MailCore doesn't parse the eml filename and.
This pull request will parse the filename and added the rfc822Headers property to the Message Part class.
