### PR TITLE
Fallback to use the "LIST" defined in "IMAP4rev1"

### DIFF
--- a/Source/CTCoreAccount.m
+++ b/Source/CTCoreAccount.m
@@ -285,6 +285,13 @@
     //Now, fill the all folders array
     //TODO Fix this so it doesn't use *
     err = mailimap_xlist([self session], "", "*", &allList);
+    
+    //NOTE: Fallback to use the "LIST" defined in "IMAP4rev1" RFC 
+    //if server doesn't support "XLIST" command (eg. Yahoo)
+    if (err == MAILIMAP_ERROR_PROTOCOL && [[self capabilities] containsObject:@"IMAP4rev1"]) {
+        err = mailimap_list([self session], "", "*", &allList);
+    }
+    
     if (err != MAILIMAP_NO_ERROR) {
         self.lastError = MailCoreCreateErrorFromIMAPCode(err);
         return nil;


### PR DESCRIPTION
Some IMAP server eg. Yahoo doesn't support the "XLIST" command. This pull request fallback to the "LIST" command defined in IMAP4rev1 (RFC 3501 http://tools.ietf.org/html/rfc3501).
