### PR TITLE
Improve the append message to mailbox in IMAP server.

### DIFF
--- a/Source/CTCoreFolder.h
+++ b/Source/CTCoreFolder.h
@@ -224,6 +224,26 @@
  @return Return YES on success, NO on error. Call method lastError to get error if one occurred
 */
 - (BOOL) appendMessage: (CTCoreMessage *) msg;
+/**
+ Exposes the IMAP APPEND command with the specified flags for the appended message, see the IMAP RFC 4549.
+ @return Return YES on success, NO on error. Call method lastError to get error if one occurred
+ */
+- (BOOL)appendMessage:(CTCoreMessage *)msg flags:(NSUInteger)flags extensionFlags:(NSArray *)extensionFlags;
+
+/**
+ Exposes the IMAP APPENDUID command and return the appended message's uid on success, see the IMAP RFC 4315.
+ @return Return YES on success, NO on error. Call method lastError to get error if one occurred
+ */
+- (BOOL)appendMessage:(CTCoreMessage *)msg
+          appendedUID:(NSUInteger *)appendMessageUID;
+/**
+ Exposes the IMAP APPENDUID command with the specified flags for the appended message and return the appended message's uid on success, see the IMAP RFC 4315 
+ @return Return YES on success, NO on error. Call method lastError to get error if one occurred
+ */
+- (BOOL)appendMessage:(CTCoreMessage *)msg
+          appendedUID:(NSUInteger *)appendMessageUID
+                flags:(NSUInteger)flags
+       extensionFlags:(NSArray *)extensionFlags;
 
 /**
  Retrieves the message flags. You must AND/OR using the defines constants.
@@ -296,7 +316,7 @@
 - (BOOL)unreadMessageCount:(NSUInteger *)unseenCount;
 
 /**
- Pass in a pointer to a NSUInteger to get the number of messages in the folder. The count was retrieved 
+ Pass in a pointer to a NSUInteger to get the number of messages in the folder. The count was retrieved
  when the folder connection was established, so to refresh the count you must disconnect and reconnect.
  @return Return YES on success, NO on error. Call method lastError to get error if one occurred
 */

--- a/Source/CTCoreFolder.m
+++ b/Source/CTCoreFolder.m
@@ -336,9 +336,10 @@ static const int MAX_PATH_SIZE = 1024;
         return NO;
     
     struct mail_flags *flags = mail_flags_new(mailFlags | MAIL_FLAG_SEEN, MailCoreClistFromStringArray(extensionFlags));
-    
+    char mbPath[MAX_PATH_SIZE];
+    [self getUTF7String:mbPath fromString:[self path]];
     err = mailsession_append_message_flags([self folderSession],
-                                           [msgStr cStringUsingEncoding: NSUTF8StringEncoding],
+                                           mbPath,
                                            [msgStr lengthOfBytesUsingEncoding: NSUTF8StringEncoding],
                                            flags);
     
@@ -370,8 +371,10 @@ static const int MAX_PATH_SIZE = 1024;
     if (err == MAIL_NO_ERROR) {
         uint32_t uidvalidity = 0;
         uint32_t messageUID = 0;
+        char mbPath[MAX_PATH_SIZE];
+        [self getUTF7String:mbPath fromString:[self path]];
         err =  mailimap_uidplus_append([self imapSession],
-                                       [self.path cStringUsingEncoding:NSUTF8StringEncoding],
+                                       mbPath,
                                        flag_list,
                                        NULL,
                                        [msgStr cStringUsingEncoding: NSUTF8StringEncoding],


### PR DESCRIPTION
Add support for set the appending message's flag.
Add support for APPENDUID command (RFC 4315) which return the appended message's uid to the caller.
