### PR TITLE
Put the hard-coded error domain name in a #define.

### DIFF
--- a/Source/MailCoreUtilities.h
+++ b/Source/MailCoreUtilities.h
@@ -32,6 +32,8 @@
 #import <Foundation/Foundation.h>
 #import <libetpan/libetpan.h>
 
+#define MailCoreErrorDomain @"mailcore"
+
 /**
      Enables logging of all streams, data is output to standard out.
 */

--- a/Source/MailCoreUtilities.m
+++ b/Source/MailCoreUtilities.m
@@ -63,7 +63,7 @@ void MailCoreDisableLogging() {
 NSError* MailCoreCreateError(int errcode, NSString *description) {
     NSMutableDictionary *errorDetail = [NSMutableDictionary dictionary];
     [errorDetail setValue:description forKey:NSLocalizedDescriptionKey];
-    return [NSError errorWithDomain:@"mailcore" code:errcode userInfo:errorDetail];
+    return [NSError errorWithDomain:MailCoreErrorDomain code:errcode userInfo:errorDetail];
 }
 
 NSError* MailCoreCreateErrorFromSMTPCode(int errcode) {


### PR DESCRIPTION
This allows callers to use the name without hard-coding it themselves.
