### PR TITLE
Get the folder's message and unread message count in one connection.

### DIFF
--- a/Source/CTCoreFolder.h
+++ b/Source/CTCoreFolder.h
@@ -303,6 +303,16 @@
 - (BOOL)totalMessageCount:(NSUInteger *)totalCount;
 
 /**
+ Pass in a pointer to a NSUInteger to get the number of unread messages. This causes a round trip to the server,
+ as it fetches the count for each call.
+ Pass in a pointer to a NSUInteger to get the number of messages in the folder. The count was retrieved
+ when the folder connection was established, so to refresh the count you must disconnect and reconnect.
+ Useful when you want to get both message count with one connection.
+ @return Return YES on success, NO on error. Call method lastError to get error if one occurred
+ */
+- (BOOL)getUnreadMessageCount:(NSUInteger *)unreadCount totalMessageCount:(NSUInteger *)totalCount;
+
+/**
  Returns the uid validity value for the folder, which can be used to determine if the
  local cached UID's are still valid, or if the server has changed UID's
 */

--- a/Source/CTCoreFolder.m
+++ b/Source/CTCoreFolder.m
@@ -883,6 +883,32 @@ static const int MAX_PATH_SIZE = 1024;
     return YES;
 }
 
+- (BOOL)getUnreadMessageCount:(NSUInteger *)unreadCount totalMessageCount:(NSUInteger *)totalCount {
+  BOOL success = [self connect];
+  if (!success) {
+    return NO;
+  }
+
+  uint32_t unseenCount = 0;
+  unsigned int junk = 0;
+  int err =  mailfolder_status(myFolder, &junk, &junk, &unseenCount);
+  if (err != MAIL_NO_ERROR) {
+    self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+    return NO;
+  }
+  
+  struct mailimap *imap = [self imapSession];
+  if (totalCount) {
+    *totalCount =  imap->imap_selection_info->sel_exists;
+  }
+  
+  if (unreadCount) {
+    *unreadCount = unseenCount;
+  }
+  
+  return YES;
+}
+
 
 - (mailsession *)folderSession; {
     return myFolder->fld_session;


### PR DESCRIPTION
Useful when you want to get both count at the same time.
