### PR TITLE
Add methods for copy or move multiple message to another mailbox.

### DIFF
--- a/Source/CTCoreFolder.h
+++ b/Source/CTCoreFolder.h
@@ -283,10 +283,24 @@
 - (BOOL)copyMessageWithUID:(NSUInteger)uid toPath:(NSString *)path;
 
 /**
+ Copies messages to a folder
+ @return Return index set contains the copied messages' uid on success, \
+ nil on error. Call method lastError to get error if one occurred
+ */
+- (NSIndexSet *)copyMessageWithUIDs:(NSIndexSet *)uids toPath:(NSString *)path;
+
+/**
  Moves a message to a folder
  @return Return YES on success, NO on error. Call method lastError to get error if one occurred
 */
 - (BOOL)moveMessageWithUID:(NSUInteger)uid toPath:(NSString *)path;
+
+/**
+ Moves messages to a folder
+ @return Return index set contains the moved messages' uid on success, \
+ nil on error. Call method lastError to get error if one occurred
+ */
+- (NSIndexSet *)moveMessageWithUIDs:(NSIndexSet *)uids toPath:(NSString *)path;
 
 /**
  Pass in a pointer to a NSUInteger to get the number of unread messages. This causes a round trip to the server, 

--- a/Source/CTCoreFolder.m
+++ b/Source/CTCoreFolder.m
@@ -41,12 +41,13 @@
 #include <unistd.h>
 
 
-//int imap_fetch_result_to_envelop_list(clist * fetch_result, struct mailmessage_list * env_list);
-//
 int uid_list_to_env_list(clist * fetch_result, struct mailmessage_list ** result,
                         mailsession * session, mailmessage_driver * driver);
 
 @interface CTCoreFolder ()
+
+- (NSIndexSet *)_copyingMessageWithUID:(NSIndexSet *)uids toPath:(NSString *)path;
+
 @end
 
 static const int MAX_PATH_SIZE = 1024;
@@ -643,23 +644,17 @@ static const int MAX_PATH_SIZE = 1024;
 
 - (NSArray *)messagesWithSequenceNumbers:(NSIndexSet *)sequenceNumbers
                          fetchAttributes:(CTFetchAttributes)attrs {
-  struct mailimap_set *set = mailimap_set_new_empty();
-  [sequenceNumbers enumerateRangesUsingBlock:^(NSRange range, BOOL *stop) {
-    mailimap_set_add_interval(set, range.location, range.location + range.length - 1);
-  }];
+    struct mailimap_set *set = mailimap_setFromIndexSet(sequenceNumbers);
   
-  return [self messagesForSet:set fetchAttributes:attrs uidFetch:NO];
+    return [self messagesForSet:set fetchAttributes:attrs uidFetch:NO];
   
 }
 
 - (NSArray *)messagesWithUIDs:(NSIndexSet *)uidNumbers
               fetchAttributes:(CTFetchAttributes)attrs {
-  struct mailimap_set *set = mailimap_set_new_empty();
-  [uidNumbers enumerateRangesUsingBlock:^(NSRange range, BOOL *stop) {
-    mailimap_set_add_interval(set, range.location, range.location + range.length - 1);
-  }];
-  
-  return [self messagesForSet:set fetchAttributes:attrs uidFetch:YES];
+    struct mailimap_set *set = mailimap_setFromIndexSet(uidNumbers);
+    
+    return [self messagesForSet:set fetchAttributes:attrs uidFetch:YES];
 }
 
 - (CTCoreMessage *)messageWithUID:(NSUInteger)uid {
@@ -841,6 +836,19 @@ static const int MAX_PATH_SIZE = 1024;
     return YES;
 }
 
+- (NSIndexSet *)copyMessageWithUIDs:(NSIndexSet *)uids toPath:(NSString *)path {
+    if (![uids count]) {
+        return [NSIndexSet indexSet];
+    }
+    
+    BOOL success = [self connect];
+    if (!success) {
+        return NO;
+    }
+    
+    return [self _copyingMessageWithUID:uids toPath:path];
+}
+
 - (BOOL)moveMessageWithUID:(NSUInteger)uid toPath:(NSString *)path {
     BOOL success = [self connect];
     if (!success) {
@@ -855,6 +863,42 @@ static const int MAX_PATH_SIZE = 1024;
         return NO;
     }
     return YES;
+}
+
+- (NSIndexSet *)moveMessageWithUIDs:(NSIndexSet *)uids toPath:(NSString *)path {
+    if (![uids count]) {
+        return [NSIndexSet indexSet];
+    }
+    
+    BOOL success = [self connect];
+    if (!success) {
+        return NO;
+    }
+    
+    NSIndexSet *destinationUIDs = [self _copyingMessageWithUID:uids toPath:path];
+    
+    if (destinationUIDs) {
+        struct mailimap_set * uidSet = mailimap_setFromIndexSet(uids);
+        struct mail_flags * mail_delete_flags = mail_flags_new(MAIL_FLAG_DELETED, clist_new());
+        struct mailimap_flag_list * imap_delete_flags;
+        imap_flags_to_imap_flags(mail_delete_flags, &imap_delete_flags);
+        
+        // Add the delete flage with silent mode (+FLAGS.SILENT).
+        struct mailimap_store_att_flags * deleteFlag = mailimap_store_att_flags_new(1, 1, imap_delete_flags);
+        int err = mailimap_uid_store([self imapSession], uidSet, deleteFlag);
+        if (err != MAIL_NO_ERROR) {
+            self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+            return nil;
+        }
+        
+        err = mailimap_expunge([self imapSession]);
+        if (err != MAIL_NO_ERROR) {
+            self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+            return nil;
+        }
+    }
+    
+    return destinationUIDs;
 }
 
 - (BOOL)unreadMessageCount:(NSUInteger *)unseenCount {
@@ -986,6 +1030,39 @@ int uid_list_to_env_list(clist * fetch_result, struct mailmessage_list ** result
         mailmessage_free(carray_get(tab, i));
     err:
         return res;
+}
+
+- (NSIndexSet *)_copyingMessageWithUID:(NSIndexSet *)uids toPath:(NSString *)path {
+    uint32_t nextUID = 0;
+    mailimap *imapSession = [self imapSession];
+    char mbPath[MAX_PATH_SIZE];
+    [self getUTF7String:mbPath fromString:path];
+    struct mailimap_set * uidSet = mailimap_setFromIndexSet(uids);
+    int err = 0;
+    struct mailimap_set * destinationUIDSet = NULL;
+    NSIndexSet *destinationUIDs = nil;
+    if (mailimap_has_uidplus(imapSession)) {
+        uint32_t uidValidity;
+        struct mailimap_set * souceUIDSet;
+        err = mailimap_uidplus_uid_copy([self imapSession], uidSet, mbPath, &uidValidity, &souceUIDSet, &destinationUIDSet);
+    } else {
+        // If IMAP server is not support for UIDPLUS extension, we will calculate the uid manually.
+        if (imapSession->imap_selection_info != NULL) {
+            nextUID = imapSession->imap_selection_info->sel_uidnext;
+        }
+        
+        err = mailimap_uid_copy(imapSession, uidSet, mbPath);
+    }
+    
+    if (err != MAIL_NO_ERROR) {
+        self.lastError = MailCoreCreateErrorFromIMAPCode(err);
+    } else if (destinationUIDSet) {
+        destinationUIDs = MailCoreIndexSetFromMailImapSet(destinationUIDSet);
+    } else if (nextUID) {
+        destinationUIDs = [NSIndexSet indexSetWithIndexesInRange:(NSRange) { nextUID, [uids count] }];
+    }
+    
+    return destinationUIDs;
 }
 
 

--- a/Source/MailCoreUtilities.h
+++ b/Source/MailCoreUtilities.h
@@ -55,3 +55,6 @@ NSString *MailCoreDecodeMIMEPhrase(char *data);
 NSArray * MailCoreStringArrayFromClist(clist *list);
 clist *MailCoreClistFromStringArray(NSArray *strings);
 
+struct mailimap_set * mailimap_setFromIndexSet(NSIndexSet *indexSet);
+NSIndexSet * MailCoreIndexSetFromMailImapSet(struct mailimap_set *set);
+

--- a/Source/MailCoreUtilities.m
+++ b/Source/MailCoreUtilities.m
@@ -312,3 +312,28 @@ clist *MailCoreClistFromStringArray(NSArray *strings) {
   
 	return str_list;
 }
+
+struct mailimap_set * mailimap_setFromIndexSet(NSIndexSet *indexSet) {
+    struct mailimap_set *set = mailimap_set_new_empty();
+    [indexSet enumerateRangesUsingBlock:^(NSRange range, BOOL *stop) {
+        mailimap_set_add_interval(set, range.location, range.location + range.length - 1);
+    }];
+    
+    return set;
+}
+
+NSIndexSet * MailCoreIndexSetFromMailImapSet(struct mailimap_set *set) {
+    if (!set || !set->set_list) {
+        return nil;
+    }
+    
+    clistiter *iter;	
+    NSMutableIndexSet *indexSet = [NSMutableIndexSet indexSet];
+    for(iter = clist_begin(set->set_list); iter != NULL; iter = clist_next(iter)) {
+        struct mailimap_set_item * set_item = clist_content(iter);
+        [indexSet addIndexesInRange:(NSRange) { set_item->set_first, set_item->set_last - set_item->set_first + 1 }];
+    }
+    
+    return [[indexSet copy] autorelease];
+}
+


### PR DESCRIPTION
Add methods for batch copying and moving message from one folder to another folders with only one command. These methods will help reducing the network transmission when moving or copying multiple messages.
