### PR TITLE
Unit tests: added folder connection test, implemented no-messageSize logic

### DIFF
--- a/Tests/CTConnectedTest.m
+++ b/Tests/CTConnectedTest.m
@@ -70,7 +70,9 @@
     self.account = [[CTCoreAccount alloc] init];
     [self connect];
     self.folder = [self.account folderWithPath:[self.credentials valueForKey:@"path"]];
-    [self.folder connect];
+    
+    BOOL folderConnected = [self.folder connect];
+    STAssertTrue(folderConnected, @"Should successfully connect to folder");
 }
 
 - (void)tearDown {

--- a/Tests/CTCoreFolderTests.m
+++ b/Tests/CTCoreFolderTests.m
@@ -32,13 +32,17 @@
 #import <MailCore/MailCore.h>
 #import "CTCoreFolderTests.h"
 
+// set expected number of messages in folder
+const int kExpectedFolderMessagesCount = 7;
+
 @implementation CTCoreFolderTests {
 
 }
 
 - (void)testFetchOnlyDefaults {
+    NSLog(@"testFetchOnlyDefaults");
     NSArray *messages = [self.folder messagesFromSequenceNumber:1 to:0 withFetchAttributes:CTFetchAttrDefaultsOnly];
-    STAssertTrue(messages.count == 6, @"");
+    STAssertEquals(kExpectedFolderMessagesCount, (int)messages.count, @"");
     CTCoreMessage *msg = [messages objectAtIndex:0];
     STAssertTrue([msg uid] > 0, @"We should have the UID");
     STAssertTrue([msg messageSize] > 0, @"We always download message size");
@@ -58,7 +62,7 @@
 
 - (void)testFetchEnvelope {
     NSArray *messages = [self.folder messagesFromSequenceNumber:1 to:0 withFetchAttributes:CTFetchAttrEnvelope];
-    STAssertTrue(messages.count == 6, @"");
+    STAssertEquals(kExpectedFolderMessagesCount, (int)messages.count, @"");
     CTCoreMessage *msg = [messages objectAtIndex:0];
     STAssertTrue([msg uid] > 0, @"We should have the UID");
     STAssertTrue([msg messageSize] > 0, @"We always download message size");
@@ -76,7 +80,7 @@
 
 - (void)testFetchEnvelopeUsingUIDFetch {
     NSArray *messages = [self.folder messagesFromUID:1 to:0 withFetchAttributes:CTFetchAttrEnvelope];
-    STAssertTrue(messages.count == 6, @"");
+    STAssertEquals(kExpectedFolderMessagesCount, (int)messages.count, @"");
     CTCoreMessage *msg = [messages objectAtIndex:0];
     STAssertTrue([msg uid] > 0, @"We should have the UID");
     STAssertTrue([msg messageSize] > 0, @"We always download message size");
@@ -93,14 +97,17 @@
 }
 
 - (void)testFetchBodyStructure {
+    NSLog(@"testFetchBodyStructure");
     NSArray *messages = [self.folder messagesFromSequenceNumber:1 to:0 withFetchAttributes:CTFetchAttrBodyStructure];
-    STAssertTrue(messages.count == 6, @"");
+    
+    STAssertEquals(kExpectedFolderMessagesCount, (int)messages.count, @"");
     CTCoreMessage *msg = [messages objectAtIndex:0];
     STAssertTrue([msg uid] > 0, @"We should have the UID");
     STAssertTrue([msg messageSize] > 0, @"We always download message size");
 
     STAssertNil([msg senderDate], @"We have no envelope so should be nil");
     STAssertNil([msg subject], @"We have no envelope so should be nil");
+    
     STAssertNil([msg to], @"We have no envelope so should be nil");
     STAssertNil([msg cc], @"We have no envelope so should be nil");
     STAssertNil([msg sender], @"We have no envelope so should be nil");
@@ -114,7 +121,7 @@
 
 - (void)testFetchEverything {
     NSArray *messages = [self.folder messagesFromSequenceNumber:1 to:0 withFetchAttributes:CTFetchAttrEnvelope | CTFetchAttrBodyStructure];
-    STAssertTrue(messages.count == 6, @"");
+    STAssertEquals(kExpectedFolderMessagesCount, (int)messages.count, @"");
     CTCoreMessage *msg = [messages objectAtIndex:0];
     STAssertTrue([msg uid] > 0, @"We should have the UID");
     STAssertTrue([msg messageSize] > 0, @"We always download message size");

--- a/Tests/CTCoreFolderTests.m
+++ b/Tests/CTCoreFolderTests.m
@@ -45,8 +45,8 @@ const int kExpectedFolderMessagesCount = 7;
     STAssertEquals(kExpectedFolderMessagesCount, (int)messages.count, @"");
     CTCoreMessage *msg = [messages objectAtIndex:0];
     STAssertTrue([msg uid] > 0, @"We should have the UID");
-    STAssertTrue([msg messageSize] > 0, @"We always download message size");
-
+    
+    STAssertNil([msg messageSize], @"We have no envelope so should be nil");
     STAssertNil([msg senderDate], @"We have no envelope so should be nil");
     STAssertNil([msg subject], @"We have no envelope so should be nil");
     STAssertNil([msg to], @"We have no envelope so should be nil");
@@ -65,7 +65,7 @@ const int kExpectedFolderMessagesCount = 7;
     STAssertEquals(kExpectedFolderMessagesCount, (int)messages.count, @"");
     CTCoreMessage *msg = [messages objectAtIndex:0];
     STAssertTrue([msg uid] > 0, @"We should have the UID");
-    STAssertTrue([msg messageSize] > 0, @"We always download message size");
+    STAssertTrue([msg messageSize] > 0, @"We DO HAVE AN envelope so should be > 0");
 
     STAssertNotNil([msg senderDate], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg subject], @"We DO HAVE AN envelope so shouldn't be nil");
@@ -83,7 +83,7 @@ const int kExpectedFolderMessagesCount = 7;
     STAssertEquals(kExpectedFolderMessagesCount, (int)messages.count, @"");
     CTCoreMessage *msg = [messages objectAtIndex:0];
     STAssertTrue([msg uid] > 0, @"We should have the UID");
-    STAssertTrue([msg messageSize] > 0, @"We always download message size");
+    STAssertTrue([msg messageSize] > 0, @"We DO HAVE AN envelope so should be > 0");
 
     STAssertNotNil([msg senderDate], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg subject], @"We DO HAVE AN envelope so shouldn't be nil");
@@ -103,11 +103,10 @@ const int kExpectedFolderMessagesCount = 7;
     STAssertEquals(kExpectedFolderMessagesCount, (int)messages.count, @"");
     CTCoreMessage *msg = [messages objectAtIndex:0];
     STAssertTrue([msg uid] > 0, @"We should have the UID");
-    STAssertTrue([msg messageSize] > 0, @"We always download message size");
-
+    
+    STAssertNil([msg messageSize], @"We have no envelope so should be nil");
     STAssertNil([msg senderDate], @"We have no envelope so should be nil");
     STAssertNil([msg subject], @"We have no envelope so should be nil");
-    
     STAssertNil([msg to], @"We have no envelope so should be nil");
     STAssertNil([msg cc], @"We have no envelope so should be nil");
     STAssertNil([msg sender], @"We have no envelope so should be nil");
@@ -124,8 +123,8 @@ const int kExpectedFolderMessagesCount = 7;
     STAssertEquals(kExpectedFolderMessagesCount, (int)messages.count, @"");
     CTCoreMessage *msg = [messages objectAtIndex:0];
     STAssertTrue([msg uid] > 0, @"We should have the UID");
-    STAssertTrue([msg messageSize] > 0, @"We always download message size");
-
+    STAssertTrue([msg messageSize] > 0, @"We DO HAVE AN envelope so should be > 0");
+    
     STAssertNotNil([msg senderDate], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg subject], @"We DO HAVE AN envelope so shouldn't be nil");
     STAssertNotNil([msg to], @"We DO HAVE AN envelope so shouldn't be nil");


### PR DESCRIPTION
Added folder connection test, implemented no-messageSize logic (message.size is available only for envelope).
Also some refactroing - now you set your expected number of messages for folder in
const int kExpectedFolderMessagesCount
.. and assert shows expected and current values
